### PR TITLE
docs: add an FAQ page

### DIFF
--- a/docs/knowledge_base/faq.md
+++ b/docs/knowledge_base/faq.md
@@ -14,7 +14,6 @@ Please [contact us][contact] to ask questions that aren't covered by the documen
 
 The Phylum application is continuously ingesting and processing packages for all supported ecosystems in an attempt to
 provide nearly instant analysis results. If a package is submitted for analysis that has not already been pre-processed,
-the application will take approximately 30 minutes to acquire the package and run the heuristics and rules to produce
-the final package score.
+the application will take approximately 30 minutes to acquire the package and run the heuristics and rules.
 
 NOTE: This process is parallelized. Having one, or 100, packages processing will generally take the same amount of time.

--- a/docs/knowledge_base/faq.md
+++ b/docs/knowledge_base/faq.md
@@ -1,0 +1,20 @@
+---
+title: Frequently Asked Questions (FAQ)
+category: 6255e67693d5200013b1fa41
+hidden: false
+---
+
+# FAQs
+
+Please [contact us][contact] to ask questions that aren't covered by the documentation or this FAQ page.
+
+[contact]: https://docs.phylum.io/docs/contact_us
+
+## How long does it take for a newly published package to be processed by Phylum?
+
+The Phylum application is continuously ingesting and processing packages for all supported ecosystems in an attempt to
+provide nearly instant analysis results. If a package is submitted for analysis that has not already been pre-processed,
+the application will take approximately 30 minutes to acquire the package and run the heuristics and rules to produce
+the final package score.
+
+NOTE: This process is parallelized. Having one, or 100, packages processing will generally take the same amount of time.


### PR DESCRIPTION
This change adds a Frequently Asked Questions (FAQ) page and populates it with some initial content. The page has been added under the "Knowledge Base" category and the first question comes from the current "Processing" page hosted at https://docs.phylum.io/docs/processing

That processing page is not currently tracked in source control. It only lives on the readme.com site. The other page like that is the "Phylum Package Score" at https://docs.phylum.io/docs/phylum-package-score

That page will not be ported since the decision was to abandon it given the content will not be relevant going forward.

Closes #30

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
