### PR TITLE
docs: add "Phylum Project Creation" page

### DIFF
--- a/docs/analytics/env_var_enumeration.md
+++ b/docs/analytics/env_var_enumeration.md
@@ -14,4 +14,4 @@ Environment variables, while generally uninteresting, can sometimes refer to cri
 
 # Examples
 
-In April of 2022, researchers discovered a set of malicious packages on PyPi that would search through environment variables looking for the location of local browser storage folders. Once found, the aim of the malware was to steal AWS or other user credentials.
+In April of 2022, researchers discovered a set of malicious packages on PyPI that would search through environment variables looking for the location of local browser storage folders. Once found, the aim of the malware was to steal AWS or other user credentials.

--- a/docs/analytics/remote_exe_ref_or_run.md
+++ b/docs/analytics/remote_exe_ref_or_run.md
@@ -14,4 +14,4 @@ Executables on their own are not inherently dangerous. In fact, most software ru
 
 # Examples
 
-In August of 2022, researchers discovered a dozen malicious packages on the PyPi repository attempting a typosquatting attack. If installed, these packages would grab a an executable payload from a malicious URL, save it to disk, and then execute the file--all from within the `setup.py`. In one observed case the executable would then recruit the host machine into a DDoS campaign against a Russian Counter-Strike server.
+In August of 2022, researchers discovered a dozen malicious packages on the PyPI repository attempting a typosquatting attack. If installed, these packages would grab a an executable payload from a malicious URL, save it to disk, and then execute the file--all from within the `setup.py`. In one observed case the executable would then recruit the host machine into a DDoS campaign against a Russian Counter-Strike server.

--- a/docs/integrations/github_app.md
+++ b/docs/integrations/github_app.md
@@ -130,7 +130,10 @@ The results will be visible in the `Project` menu view for the selected project 
 
 ## FAQ
 
-1. Q: I activated monitoring, but it didn't run a scan. How do I get analysis results?
-   * A: Check to ensure the repository contains a [supported lockfile](https://docs.phylum.io/docs/analyzing-dependencies).
-2. Q: Can I manage multiple GitHub App installations in Phylum?
-   * A: Yes! If your account is linked to multiple GitHub App installtions, they will be displayed and selectable on the left side of the GitHub App Settings page in the Phylum UI.
+### I activated monitoring, but it didn't run a scan. How do I get analysis results?
+
+Check to ensure the repository contains a [supported lockfile](https://docs.phylum.io/docs/analyzing-dependencies).
+
+### Can I manage multiple GitHub App installations in Phylum?
+
+Yes! If your account is linked to multiple GitHub App installtions, they will be displayed and selectable on the left side of the GitHub App Settings page in the Phylum UI.

--- a/docs/knowledge_base/create_project.md
+++ b/docs/knowledge_base/create_project.md
@@ -1,0 +1,85 @@
+---
+title: Phylum Project Creation
+category: 6255e67693d5200013b1fa41
+hidden: false
+---
+
+# Overview
+
+Phylum projects are used to represent a software project; often a git repository. A Phylum project organizes the dependencies and findings for your software project. This page enumerates the ways a Phylum project can be created.
+
+## Walkthrough
+
+### Phylum CLI
+
+#### Via `phylum init` command
+
+1. Navigate to the directory of the relevant software project
+2. Use the [CLI tool](https://docs.phylum.io/docs/quickstart) to initialize a Phylum project, the interactive prompt will default to the name of the directory, or you may specify the desired project name
+
+```shellsession
+❯ pwd
+~/dev/a-phylum-demo
+
+❯ phylum init
+Project Name [default: a-phylum-demo]:
+
+[ENTER] Confirm
+Project Group: demo-group
+
+[SPACE] Select  [ENTER] Confirm
+Select your project's lockfiles and manifests: ./requirements.txt
+
+✅ Successfully created project configuration
+
+❯ cat .phylum_project
+id: 49158d65-76aa-46f2-89f3-6a50419cfc3d
+name: a-phylum-demo
+created_at: 2023-07-21T19:16:44.830526-05:00
+group_name: demo-group
+lockfiles:
+- path: ./requirements.txt
+  type: pip
+```
+
+#### Via `phylum project` command
+
+1. Navigate to the directory of the relevant software project
+2. Use the [CLI tool](https://docs.phylum.io/docs/quickstart) to create a new Phylum project
+
+Note: This will create a `.phylum_project` file in the current directory
+
+Example:
+
+```sh
+phylum project create sample
+```
+
+### Phylum-CI
+
+The [`phylum-ci` tool](https://pypi.org/project/phylum/) accepts a `--project` option to explicitly provide the name of a Phylum project to create and use to perform the analysis. You can also specify this option's value in the `.phylum_project` file. A project name provided as an input option will be preferred over an entry in the `.phylum_project` file.
+
+When no project name is provided through options or project file, a project name will be provided by detecting the git repository name. The goal is a unique and deterministic project name for each git repository submitted by the same Phylum user account.
+
+Each of the examples here result in the same `sample` project used and created if it doesn't already exist:
+
+```sh
+# Execute `phylum-ci` specifying a project named "sample"
+phylum-ci --project sample
+
+# A `.phylum_project` file exists with an entry of `name: sample`
+phylum-ci
+
+# No `.phylum_project` file exists, but the git repository name is `sample`
+phylum-ci
+```
+
+### GitHub App
+
+1. The [Phylum GitHub App](https://docs.phylum.io/docs/github_app) will automatically create a Phylum project when monitoring is activated for a given repository. The Phylum project will be assigned the same name as the repository.
+
+## FAQ
+
+### Can Phylum projects be shared with other accounts?
+
+Yes! This feature is available to Pro users via groups.

--- a/docs/knowledge_base/create_project.md
+++ b/docs/knowledge_base/create_project.md
@@ -8,11 +8,15 @@ hidden: false
 
 Phylum projects are used to represent a software project; often a git repository. A Phylum project organizes the dependencies and findings for your software project. This page enumerates the ways a Phylum project can be created.
 
+> **NOTE:** Project creation does not trigger an analysis of the project. Instead, the [`phylum analyze`](https://docs.phylum.io/docs/phylum_analyze) command will trigger an analysis job and organize the results in the specified Phylum project.
+
 ## Walkthrough
 
 ### Phylum CLI
 
-#### Via `phylum init` command
+---
+
+**Via [`phylum init`](https://docs.phylum.io/docs/phylum_init) command:**
 
 1. Navigate to the directory of the relevant software project
 2. Use the [CLI tool](https://docs.phylum.io/docs/quickstart) to initialize a Phylum project, the interactive prompt will default to the name of the directory, or you may specify the desired project name
@@ -42,7 +46,9 @@ lockfiles:
   type: pip
 ```
 
-#### Via `phylum project` command
+---
+
+**Via [`phylum project`](https://docs.phylum.io/docs/phylum_project) command:**
 
 1. Navigate to the directory of the relevant software project
 2. Use the [CLI tool](https://docs.phylum.io/docs/quickstart) to create a new Phylum project
@@ -82,4 +88,4 @@ phylum-ci
 
 ### Can Phylum projects be shared with other accounts?
 
-Yes! This feature is available to Pro users via groups.
+Yes! This feature is available to Pro users via [groups](https://docs.phylum.io/docs/groups).

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -20,39 +20,40 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
   - Malicious Code (`M`)
   - Vulnerabilities (`V`)
   - License Risk (`L`)
-    
+
+---
 
 | Tag ID | Issue Name | Issue Description |
 | --- | --- | --- |
-| CA0001    | [Bad Author](https://docs.phylum.io/docs/bad_author) | Author is known malicious |
-| CM0001    | [IP Detection](https://docs.phylum.io/docs/ip_identification) | Package contains suspicious IP addresses |
-| CM0003    | Landing Binary | Package is using living off the land binaries in a known malicious way |
-| .M0004    | Landing Binary | Package uses suspicious executables |
-| IL0005    | License | Commercial license risk detected |
-| IM0006    | NPM Hooks | Package uses install hooks to ask for donations |
-| CM0007    | [NPM Hooks](https://docs.phylum.io/docs/npm_hooks) | Package executes shell commands in installation hooks |
-| IM0007    | NPM Hooks | Package runs the software immediately after installation |
-| HM0008    | [Typosquatting](https://docs.phylum.io/docs/typosquatting) | Package appears to be typosquatted |
-| CM0011    | [Hostname Detection](https://docs.phylum.io/docs/hostname_identification) | Package contains suspicious hostnames |
-| MM0012    | [Native Code](https://docs.phylum.io/docs/invokes_native_code) | Package contains calls used to load native code |
-| IM0013    | Dynamic Code | Package contains calls used to run dynamic classes |
-| ME0016    | [Secrets](https://docs.phylum.io/docs/secrets) | Secrets/tokens found in package not in test or example file |
-| IE0016    | [Secrets](https://docs.phylum.io/docs/secrets) | Secrets/tokens found in package in test or example file |
-| IM0017    | [Compiled Binaries](https://docs.phylum.io/docs/compiled_binary) | Package contains compiled binaries |
-| HM0018    | [Dependency Confusion](https://docs.phylum.io/docs/dependency_confusion) | Package has unusual semver or not found in registry |
-| IL0022    | License Mismatch | Package has a license mismatch between metadata and files |
-| HA0023    | [Ephemeral Author Domain](https://docs.phylum.io/docs/ephemeral_domain) | A disposable domain was used by a maintainer |
-| IE0023    | [IP Detection](https://docs.phylum.io/docs/ip_identification) | This package may contain hardcoded IP addresses. |
-| HM0023    | [Strange Python Imports](https://docs.phylum.io/docs/strange_python_imports) | Package imports things in a strange way |
-| CM0024    | [Remote Executable](https://docs.phylum.io/docs/remote_exe_ref_or_run) | Package runs remote executable |
-| MM0024    | [Remote Executable](https://docs.phylum.io/docs/remote_exe_ref_or_run) | Package references remote executable |
-| HM0025    | [Environment Variable Enumeration](https://docs.phylum.io/docs/env_var_enumeration) | Package enumerates through user folders |
-| IE0027    | [Trivial Package](https://docs.phylum.io/docs/trivial_package) | Package may be too small to be worth the security risk |
-| MM0028    | [Suspicious URL References](https://docs.phylum.io/docs/suspicious_url_references) | Package references pastebin-like sites |
-| HM0029    | [Obfuscated Python](https://docs.phylum.io/docs/obfuscated_python) | Package contains obfuscated Python |
-| .M0031    | [Suspicious Commands In Setup.py](https://docs.phylum.io/docs/suspicious_setup_commands) | Package contains unusual commands in setup.py |
-| HM0032    | [Exec on Remote URL](https://docs.phylum.io/docs/executes_code_at_remote_url) | Package calls `exec` on a remote URL |
-| HM0036    | [Webhook Exfil](https://docs.phylum.io/docs/webhook_exfil) | A package that appears to exfil data through a webhook |
-| HM0037    | Malware Bazaar Check | A package's file contains a hash that hits on Malware Bazaar |
-| CM0038    | Triaged Malware Rule (via threat feed) | Manually reviewed and confirmed to contain malware |
-| HM0099    | [Basic Javascript Obfuscation](https://docs.phylum.io/docs/obfuscated_javascript) | Package contains obfuscated Javascript |
+| CA0001 | [Bad Author](https://docs.phylum.io/docs/bad_author) | Author is known malicious |
+| CM0001 | [IP Detection](https://docs.phylum.io/docs/ip_identification) | Package contains suspicious IP addresses |
+| CM0003 | Landing Binary | Package is using living off the land binaries in a known malicious way |
+| .M0004 | Landing Binary | Package uses suspicious executables |
+| IL0005 | License | Commercial license risk detected |
+| IM0006 | [NPM Hooks](https://docs.phylum.io/docs/npm_hooks) | Package uses install hooks to ask for donations |
+| CM0007 | [NPM Hooks](https://docs.phylum.io/docs/npm_hooks) | Package executes shell commands in installation hooks |
+| IM0007 | [NPM Hooks](https://docs.phylum.io/docs/npm_hooks) | Package runs the software immediately after installation |
+| HM0008 | [Typosquatting](https://docs.phylum.io/docs/typosquatting) | Package appears to be typosquatted |
+| CM0011 | [Hostname Detection](https://docs.phylum.io/docs/hostname_identification) | Package contains suspicious hostnames |
+| MM0012 | [Native Code](https://docs.phylum.io/docs/invokes_native_code) | Package contains calls used to load native code |
+| IM0013 | Dynamic Code | Package contains calls used to run dynamic classes |
+| ME0016 | [Secrets](https://docs.phylum.io/docs/secrets) | Secrets/tokens found in package not in test or example file |
+| IE0016 | [Secrets](https://docs.phylum.io/docs/secrets) | Secrets/tokens found in package in test or example file |
+| IM0017 | [Compiled Binaries](https://docs.phylum.io/docs/compiled_binary) | Package contains compiled binaries |
+| HM0018 | [Dependency Confusion](https://docs.phylum.io/docs/dependency_confusion) | Package has unusual semver or not found in registry |
+| IL0022 | License Mismatch | Package has a license mismatch between metadata and files |
+| HA0023 | [Ephemeral Author Domain](https://docs.phylum.io/docs/ephemeral_domain) | A disposable domain was used by a maintainer |
+| IE0023 | [IP Detection](https://docs.phylum.io/docs/ip_identification) | This package may contain hardcoded IP addresses |
+| HM0023 | [Strange Python Imports](https://docs.phylum.io/docs/strange_python_imports) | Package imports things in a strange way |
+| CM0024 | [Remote Executable](https://docs.phylum.io/docs/remote_exe_ref_or_run) | Package runs remote executable |
+| MM0024 | [Remote Executable](https://docs.phylum.io/docs/remote_exe_ref_or_run) | Package references remote executable |
+| HM0025 | [Environment Variable Enumeration](https://docs.phylum.io/docs/env_var_enumeration) | Package enumerates sensitive system environment variables |
+| IE0027 | [Trivial Package](https://docs.phylum.io/docs/trivial_package) | Package may be too small to be worth the security risk |
+| MM0028 | [Suspicious URL References](https://docs.phylum.io/docs/suspicious_url_references) | Package references sites uncommon to legitimate software |
+| HM0029 | [Obfuscated Python](https://docs.phylum.io/docs/obfuscated_python) | Package contains obfuscated Python |
+| .M0031 | [Suspicious Python Setup Commands](https://docs.phylum.io/docs/suspicious_setup_commands) | Package contains unusual commands in `setup.py` |
+| HM0032 | [Exec on Remote URL](https://docs.phylum.io/docs/executes_code_at_remote_url) | Package executes code from a remote URL |
+| HM0036 | [Webhook Exfil](https://docs.phylum.io/docs/webhook_exfil) | Package exfiltrates data through a webhook |
+| HM0037 | Malware Bazaar Check | Package contains a file whose hash is in Malware Bazaar |
+| CM0038 | Triaged Malware Rule (via [threat feed](https://docs.phylum.io/docs/threat_feed)) | Manually reviewed and confirmed to contain malware |
+| HM0099 | [Basic Javascript Obfuscation](https://docs.phylum.io/docs/obfuscated_javascript) | Package contains obfuscated Javascript |


### PR DESCRIPTION
This PR adds a "Phylum Project Creation" page. It was originally part of #54, but that PR was superseded by #56. The new page will exist in the Knowledge Base and can be referenced from there. It details the ways in which a Phylum project can be created. Some additional documentation cleanup was done in this change as well:

* Change instances of `PyPi` to `PyPI` for consistency and correctness
* Ensure FAW sections are formatted consistently throughout the repo
* Clean up the "Issue Tags" page
  * Remove extra whitespace
  * Add links to rules
  * Be consistent on punctuation
  * Clarify issue descriptions based on a review of the underlying rules
