### PR TITLE
docs: update dead links

### DIFF
--- a/docs/home/changelog.md
+++ b/docs/home/changelog.md
@@ -18,7 +18,7 @@ hidden: false
 ### New
 - Threat Feed: Added a threat feed capability highlighting software supply chain attacks (contact [sales](mailto:sales@phylum.io) if interested)
 - Dashboard: Created Dashboard view showing software supply chain statistics
-- CLI: Added support for lockfile generation from manifest files (updated list of supported filetypes [here](https://docs.phylum.io/docs/analyzing-dependencies))
+- CLI: Added support for lockfile generation from manifest files (updated list of supported filetypes [here](https://docs.phylum.io/docs/lockfile_generation))
 
 ### Improved
 - CLI: Added `pip` version checking to the `phylum pip` extension

--- a/docs/home/defend_your_workstation.md
+++ b/docs/home/defend_your_workstation.md
@@ -96,11 +96,11 @@ up to date in 122ms
 
 ## Supported Ecosystems
 
-Phylum provides support for a number of common package managers used in the [supported ecosystems](https://docs.phylum.io/docs/analyzing-dependencies). These include `npm`, `yarn`, `pip`, `poetry`, `bundle`, `cargo` and more on the way! To get the current list, check the [official extensions](https://github.com/phylum-dev/cli/tree/main/extensions). The ecosystem extensions there are included by default when installing the Phylum CLI.
+Phylum provides support for a number of common package managers used in the [supported ecosystems](https://docs.phylum.io/docs/supported_lockfiles). These include `npm`, `yarn`, `pip`, `poetry`, `bundle`, `cargo` and more on the way! To get the current list, check the [official extensions](https://github.com/phylum-dev/cli/tree/main/extensions). The ecosystem extensions there are included by default when installing the Phylum CLI.
 
 Note: The pre-check feature is available for all listed ecosystem extensions, but the installation sandbox component is currently only supported for `npm`, `yarn`, and `pip`.
 
-Phylum may not currently provide an official ecosystem extension for a package manager that [is otherwise supported](https://docs.phylum.io/docs/analyzing-dependencies). Please do one of the following to get that support:
+Phylum may not currently provide an official ecosystem extension for a package manager that [is otherwise supported](https://docs.phylum.io/docs/supported_lockfiles). Please do one of the following to get that support:
 
 * Check the [community extensions repository](https://github.com/phylum-dev/community-extensions)
   * Someone else may have already made the extension

--- a/docs/integrations/github_app.md
+++ b/docs/integrations/github_app.md
@@ -48,7 +48,7 @@ Monitoring can be activated or paused by selecting the toggle for a given reposi
 >
 > ![GitHub app settings - PRO](https://raw.githubusercontent.com/phylum-dev/documentation/main/assets/gh_app_settings_pro.png)
 
-A monitored repository will automatically run a Phylum check for every commit to a Pull Request looking for changes to [supported lockfiles](https://docs.phylum.io/docs/analyzing-dependencies). If a change is found, the lockfile is submitted for analysis:
+A monitored repository will automatically run a Phylum check for every commit to a Pull Request looking for changes to [supported lockfiles](https://docs.phylum.io/docs/supported_lockfiles). If a change is found, the lockfile is submitted for analysis:
 
 ![GitHub app status check in PR](https://raw.githubusercontent.com/phylum-dev/documentation/main/assets/gh_app_status_check_running.png)
 
@@ -118,7 +118,7 @@ That takes you to the `Checks` tab of the PR, where it is possible to re-run the
 
 ### On-demand Analysis
 
-It is possible to perform on-demand analysis of any repository for which the Phylum GitHub app has visibility. This includes all the repositories in the GitHub App Settings menu, whether or not they are actively monitored. The analysis will be of the current state of **the default branch** in the repository, for the [supported lockfiles](https://docs.phylum.io/docs/analyzing-dependencies) that exist there.
+It is possible to perform on-demand analysis of any repository for which the Phylum GitHub app has visibility. This includes all the repositories in the GitHub App Settings menu, whether or not they are actively monitored. The analysis will be of the current state of **the default branch** in the repository, for the [supported lockfiles](https://docs.phylum.io/docs/supported_lockfiles) that exist there.
 
 To perform an on-demand analysis, click the `Analyze` button for the desired repository:
 
@@ -132,7 +132,7 @@ The results will be visible in the `Project` menu view for the selected project 
 
 ### I activated monitoring, but it didn't run a scan. How do I get analysis results?
 
-Check to ensure the repository contains a [supported lockfile](https://docs.phylum.io/docs/analyzing-dependencies).
+Check to ensure the repository contains a [supported lockfile](https://docs.phylum.io/docs/supported_lockfiles).
 
 ### Can I manage multiple GitHub App installations in Phylum?
 


### PR DESCRIPTION
With the recent release of the CLI v5.7.1, documentation was updated. The big changes are:

* https://docs.phylum.io/docs/analyzing-dependencies was replaced by https://docs.phylum.io/docs/analyzing_dependencies and https://docs.phylum.io/docs/supported_lockfiles
* https://docs.phylum.io/docs/lockfile-generation was replaced by https://docs.phylum.io/docs/lockfile_generation

This PR updates the links in this repository to match.