### PR TITLE
docs: account for multiple `phylum-ci` image options

### DIFF
--- a/docs/home/welcome.md
+++ b/docs/home/welcome.md
@@ -58,7 +58,7 @@ phylum init
 ### Analyze your Project
 
 To begin analyzing your project for software supply chain risks, submit your
-lockfiles to Phylum.
+dependency files to Phylum.
 
 Resource: https://blog.phylum.io/insights-and-resources/pick-a-python-lockfile-and-improve-security
 

--- a/docs/integrations/github_actions.md
+++ b/docs/integrations/github_actions.md
@@ -12,16 +12,113 @@ The primary method is through the `phylum-dev/phylum-analyze-pr-action` action.
 This action is available in the [GitHub Actions Marketplace][marketplace].
 Full documentation can be found there or by viewing the [Phylum Analyze PR action repository][repo] directly.
 
-The Phylum Analyze PR action is a [Docker container action][container_action].
-This has the advantage of ensuring everything needed to work with Phylum for analyzing a PR
-for dependencies in lockfiles is self contained and known to function as a single unit.
-There are some disadvantages and some users may prefer a different solution.
-
 [marketplace]: https://github.com/marketplace/actions/phylum-analyze-pr
 [repo]: https://github.com/phylum-dev/phylum-analyze-pr-action
-[container_action]: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
 
 ## Alternatives
+
+The Phylum Analyze PR action is a [Docker container action][container_action]. The default `phylum-ci` Docker
+image it uses contains `git` and the installed `phylum` Python package. It also contains an installed version
+of the Phylum CLI and all required tools needed for [lockfile generation][lockfile_generation].
+An advantage of using the default Docker image is that the complete environment is packaged and made available
+with components that are known to work together.
+
+One disadvantage to the default image is it's size. It can take a while to download and may provide more
+tools than required for your specific use case. Special `slim` tags of the `phylum-ci` image are provided as
+an alternative. These tags differ from the default image in that they do not contain the required tools needed
+for [lockfile generation][lockfile_generation] (with the exception of the `pip` tool). The `slim` tags are
+significantly smaller and allow for faster action run times. They are useful for those instances where **no**
+manifest files are present and/or **only** lockfiles are used.
+
+Using the slim image tags is possible by altering your workflow to use the image directly instead of this
+GitHub Action. That is possible with either [container jobs](#container-jobs) or [container steps](#container-steps).
+
+[container_action]: https://docs.github.com/en/actions/creating-actions/creating-a-docker-container-action
+[lockfile_generation]: https://docs.phylum.io/docs/lockfile_generation
+
+### Container Jobs
+
+GitHub Actions allows for workflows to run a job within a container, using the `container:` statement in the
+workflow file. These are known as container jobs. More information can be found in GitHub documentation:
+["Running jobs in a container"][container_job]. To use a `slim` tag in a container job, use this minimal
+configuration:
+
+```yaml
+name: Phylum_analyze
+on: pull_request
+jobs:
+  analyze_deps:
+    name: Analyze dependencies with Phylum
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    container:
+      image: docker://ghcr.io/phylum-dev/phylum-ci:slim
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+        PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Analyze dependencies
+        run: phylum-ci -vv
+```
+
+The `image:` value is set to the latest slim image, but other tags are available to ensure a specific release
+of the `phylum-ci` project and a specific version of the Phylum CLI. The full list of available `phylum-ci`
+image tags can be viewed on [GitHub Container Registry][ghcr_tags] (preferred) or [Docker Hub][docker_hub_tags].
+
+The `GITHUB_TOKEN` and `PHYLUM_API_KEY` environment variables are required to have those exact names.
+Those environment variables and the rest of the options are more fully documented in the
+[Phylum Analyze PR action repository][repo].
+
+[container_job]: https://docs.github.com/actions/using-jobs/running-jobs-in-a-container
+[ghcr_tags]: https://github.com/phylum-dev/phylum-ci/pkgs/container/phylum-ci
+[docker_hub_tags]: https://hub.docker.com/r/phylumio/phylum-ci/tags
+
+### Container Steps
+
+GitHub Actions allows for workflows to run a step within a container, by specifying that container image in
+the `uses:` statement of the workflow step. These are known as container steps. More information can be found
+in [GitHub workflow syntax documentation][container_step]. To use a `slim` tag in a container step, use this
+minimal configuration:
+
+```yaml
+name: Phylum_analyze
+on: pull_request
+jobs:
+  analyze_deps:
+    name: Analyze dependencies with Phylum
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Analyze dependencies
+        uses: docker://ghcr.io/phylum-dev/phylum-ci:slim
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          PHYLUM_API_KEY: ${{ secrets.PHYLUM_TOKEN }}
+        with:
+          args: phylum-ci -vv
+```
+
+The `uses:` value is set to the latest slim image, but other tags are available to ensure a specific release
+of the `phylum-ci` project and a specific version of the Phylum CLI. The full list of available `phylum-ci`
+image tags can be viewed on [GitHub Container Registry][ghcr_tags] (preferred) or [Docker Hub][docker_hub_tags].
+
+The `GITHUB_TOKEN` and `PHYLUM_API_KEY` environment variables are required to have those exact names.
+Those environment variables and the rest of the options are more fully documented in the
+[Phylum Analyze PR action repository][repo].
+
+[container_step]: https://docs.github.com/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses
 
 ### Direct `phylum` Python Package Use
 
@@ -34,14 +131,3 @@ See the [Installation][installation] and [Usage][usage] sections of the [README 
 [readme]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md
 [installation]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#installation
 [usage]: https://github.com/phylum-dev/phylum-ci/blob/main/README.md#usage
-
-### Container Jobs
-
-There is another way to use the `phylumio/phylum-ci` Docker image,
-but without it being encapsulated in the Phylum Analyze PR action directly.
-GitHub Actions allows for workflows to run a job within a container,
-using the `container:` statement in the workflow file.
-These are known as container jobs.
-More information can be found in GitHub documentation: ["Running jobs in a container"][container_job].
-
-[container_job]: https://docs.github.com/actions/using-jobs/running-jobs-in-a-container

--- a/docs/integrations/github_app.md
+++ b/docs/integrations/github_app.md
@@ -137,3 +137,9 @@ Check to ensure the repository contains a [supported lockfile](https://docs.phyl
 ### Can I manage multiple GitHub App installations in Phylum?
 
 Yes! If your account is linked to multiple GitHub App installtions, they will be displayed and selectable on the left side of the GitHub App Settings page in the Phylum UI.
+
+### I want to monitor manifest files. Is that possible?
+
+It is not currently possible to monitor and analyze dependency manifest files. The GitHub App is limited to lockfiles
+only. If you still want to analyze manifest files, consider using the
+[Phylum GitHub Actions Integration](https://docs.phylum.io/docs/github_actions) instead.

--- a/docs/integrations/sophos.md
+++ b/docs/integrations/sophos.md
@@ -13,7 +13,7 @@ You will need:
 
 1. A Phylum API token
 2. (if required) An SSH key for accessing your Git repository
-3. A Git repository containing a lockfile
+3. A Git repository containing a dependency file
 
 ## Setting Your Phylum API Token
 

--- a/docs/knowledge_base/groups.md
+++ b/docs/knowledge_base/groups.md
@@ -8,7 +8,7 @@ Phylum groups allow users to view/submit projects and analysis jobs in a shared 
 
 1. [Create a group](https://docs.phylum.io/docs/phylum_group_create) for your team to use
 2. [Create a project](https://docs.phylum.io/docs/phylum_project_create) using the `--group` option and your group name
-3. [Analyze](https://docs.phylum.io/docs/phylum_analyze) the desired lock file
+3. [Analyze](https://docs.phylum.io/docs/phylum_analyze) the desired dependency files
 
 Any user that is a member of the group will be able to access the analysis results.
 

--- a/docs/knowledge_base/policy.md
+++ b/docs/knowledge_base/policy.md
@@ -5,9 +5,10 @@ hidden: false
 ---
 
 # Overview
+
 Phylum's custom policy support allows you to take control over the allow/block decision for dependencies being added to a Phylum project.
 
-# How it works
+## How it works
 
 When a developer introduces dependency changes, either in a pull request when using one of the source control server integrations or when using Phylum's CLI extensions, a simple policy is applied to determine whether or not that change should be allowed. This policy is implemented using [Open Policy Agent].
 

--- a/docs/knowledge_base/policy_basics.md
+++ b/docs/knowledge_base/policy_basics.md
@@ -20,9 +20,10 @@ import future.keywords.if
 # schemas:
 #   - data.issue: schema.issue
 issue contains "risk level cannot exceed medium" if {
-	data.issue.severity > level.MEDIUM
+    data.issue.severity > level.MEDIUM
 }
 ```
+
 This is a basic policy using an `issue` rule to block any HIGH/CRITICAL issues.
 
 The `issue` rule will contain the specified text when the `if` statement is `true`. `OPA` iterates through the job input data evaluating the expression against the severity and the level.

--- a/docs/knowledge_base/policy_development.md
+++ b/docs/knowledge_base/policy_development.md
@@ -4,19 +4,19 @@ category: 6255e67693d5200013b1fa41
 hidden: false
 ---
 
-# Creating a local policy development environment
+## Creating a local policy development environment
 
 It is recommended to set up a local development environment for a better policy development experience. With a local development environment, you gain benefits such as faster feedback, more diagnostic abilities, version control, and automated testing.
 
-## Download the OPA CLI
+### Download the OPA CLI
 
-Follow the instructions at https://www.openpolicyagent.org/docs/latest/#1-download-opa to download a copy of the OPA command line tool and run `opa version` to ensure it is working.
+Follow the instructions at <https://www.openpolicyagent.org/docs/latest/#1-download-opa> to download a copy of the OPA command line tool and run `opa version` to ensure it is working.
 
-## Download the policy SDK
+### Download the policy SDK
 
-Download the policy SDK from https://api.phylum.io/api/v0/data/jobs/policy/sdk.zip and extract it.
+Download the policy SDK from <https://api.phylum.io/api/v0/data/jobs/policy/sdk.zip> and extract it.
 
-## Download input data
+### Download input data
 
 ```sh
 job="YOUR JOB ID"
@@ -26,7 +26,7 @@ curl -H "Authorization: Bearer ${token}" "https://api.phylum.io/api/v0/data/jobs
 
 Note: You can obtain a Job ID by using the [`phylum history`](https://docs.phylum.io/docs/phylum_history) command from the Phylum CLI.
 
-# Evaluating policies locally
+## Evaluating policies locally
 
 A policy can be evaluated using `opa eval --data phylum.rego --data <YOUR POLICY>.rego --data constants.json --input input.json --schema schema --format pretty data.phylum.job`.
 
@@ -50,7 +50,7 @@ If everything is working, you will receive JSON output from `opa` that looks lik
 
 This is what the output looks like when the job is allowed by the policy. When the policy blocks something, there will be additional data describing the failure.
 
-# Automated testing
+## Automated testing
 
 Open Policy Agent has documentation on [policy testing](https://www.openpolicyagent.org/docs/latest/policy-testing/). Writing an automated test for your Phylum policy looks something like this:
 
@@ -86,7 +86,7 @@ test_allow_medium if {
 
 This test requires `constants.json` from the Phylum SDK. The test can be executed against the Phylum `default.rego` policy using `opa test constants.json default.rego example_test.rego`.
 
-# Evaluating policies using the Phylum API
+## Evaluating policies using the Phylum API
 
 Using the [`evaluate_policy`](https://api.phylum.io/api/v0/swagger/index.html#/Jobs/evaluate_policy) API, it's possible to evaluate policies within Phylum. This is the same API used by Phylum tooling.
 

--- a/docs/knowledge_base/policy_examples.md
+++ b/docs/knowledge_base/policy_examples.md
@@ -30,8 +30,8 @@ import future.keywords.in
 # schemas:
 #   - data.issue: schema.issue
 issue contains "risk level cannot exceed medium" if {
-	data.issue.domain in {domain.AUTHOR, domain.ENGINEERING, domain.VULNERABILITY}
-	data.issue.severity > level.MEDIUM
+  data.issue.domain in {domain.AUTHOR, domain.ENGINEERING, domain.VULNERABILITY}
+  data.issue.severity > level.MEDIUM
 }
 
 # METADATA
@@ -39,8 +39,8 @@ issue contains "risk level cannot exceed medium" if {
 # schemas:
 #   - data.issue: schema.issue
 issue contains "malicious risk level cannot exceed low" if {
-	data.issue.domain == domain.MALICIOUS
-	data.issue.severity > level.LOW
+  data.issue.domain == domain.MALICIOUS
+  data.issue.severity > level.LOW
 }
 
 # METADATA
@@ -48,8 +48,8 @@ issue contains "malicious risk level cannot exceed low" if {
 # schemas:
 #   - data.issue: schema.issue
 issue contains "license risk level cannot exceed high" if {
-	data.issue.domain == domain.LICENSE
-	data.issue.severity > level.HIGH
+  data.issue.domain == domain.LICENSE
+  data.issue.severity > level.HIGH
 }
 ```
 

--- a/docs/knowledge_base/threat_feed.md
+++ b/docs/knowledge_base/threat_feed.md
@@ -6,23 +6,20 @@ hidden: false
 
 The Phylum threat feed provides a curated view into malware being released across the open source ecosystems that we monitor. Packages that appear on this feed originate from our automated risk analysis platform, before being triaged and reviewed by a team of security researchers. This produces a timely, high signal feed of threats; [packages now attributed to North Korean state actors](https://blog.phylum.io/sophisticated-ongoing-attack-discovered-on-npm/) appeared on this threat feed before publication of our research article.
 
-<aside>
-ℹ️ The threat feed is its own subscription and is not part of either Phylum Pro or Phylum Community editions.
-
-</aside>
+> ℹ️ The threat feed is its own subscription and is not part of either Phylum Pro or Phylum Community editions.
 
 ## Quickstart
 
 1. Obtain an [API key](https://docs.phylum.io/docs/api-keys) and set it as follows:
-    
+
     ```bash
     PHYLUM_API=p0_...
     ```
-    
+
 2. Use your API key to retrieve the latest packages in the threat feed:
-    
+
     ```bash
-    curl https://threats.phylum.io -H "Authorization: Bearer $PHYLUM_API" 
+    curl https://threats.phylum.io -H "Authorization: Bearer $PHYLUM_API"
     ```
 
 ## API Response
@@ -35,9 +32,9 @@ For example:
 
 ```json
 {
-	"has_next": (true|false),
-	"has_previous": (true|false),
-	"packages": [...]
+  "has_next": (true|false),
+  "has_previous": (true|false),
+  "packages": [...]
 }
 ```
 
@@ -84,7 +81,7 @@ Below is an example API response from the threat feed. The top-level keys are:
       "name": "cz-react-ui-library",
       "version": "8.0.0"
     },
-		...
+  ...
   ]
 }
 ```
@@ -101,6 +98,6 @@ The threat feed API provides several parameters for interacting with the feed it
 
 For example, if you want to limit the items per page to 3 since July 19, 2023 you would perform a `GET` request to:
 
-```
+```text
 https://threats.phylum.io/?per_page=3&since=2023-07-19
 ```


### PR DESCRIPTION
These documentation updates are meant to go out with a coordinated release of the `phylum-ci` tool when it offers manifest support and lockfile generation. Specific actions taken include:

* Provide information about the `slim` tags for the `phylum-ci` image
* Provide detailed alternatives for the GitHub Action
  * For container jobs
  * For container steps
* Add more examples in the integrations docs
  * For manifests
  * For workspace manifests
  * For how to specify explicit dependency files and paths
* Clarify that the GitHub App only supports lockfiles and not manifests
* Change "lockfile" language to "dependency file" where it makes sense
* Format throughout
  * Adhere to `markdownlint` findings

Closes #61

## Checklist

- [x] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [x] Have you ensured that you have met the expected acceptance criteria?
