### PR TITLE
docs: account for breaking `phylum-ci` changes

### DIFF
--- a/docs/integrations/azure_pipelines.md
+++ b/docs/integrations/azure_pipelines.md
@@ -299,14 +299,14 @@ view the [script options output][script_options] for the latest release.
 
       # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
       # they can be named differently and may or may not contain strict dependencies.
-      # In these cases it is best to specify an explicit path, either with the `--lockfile`
+      # In these cases it is best to specify an explicit path, either with the `--depfile`
       # option or in a `.phylum_project` file. The easiest way to do that is with the
       # Phylum CLI, using the `phylum init` command (https://docs.phylum.io/docs/phylum_init)
       # and committing the generated `.phylum_project` file.
-      - script: phylum-ci --lockfile requirements-prod.txt
+      - script: phylum-ci --depfile requirements-prod.txt
 
       # Specify multiple explicit dependency file paths
-      - script: phylum-ci --lockfile requirements-prod.txt Cargo.toml path/to/dependency.file
+      - script: phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
       # Force analysis, even when no dependency file has changed. This can be useful for
       # manifests, where the loosely specified dependencies may not change often but the
@@ -315,7 +315,7 @@ view the [script options output][script_options] for the latest release.
 
       # Force analysis for all dependencies in a manifest file. This is especially useful
       # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
-      - script: phylum-ci --force-analysis --all-deps --lockfile Cargo.toml
+      - script: phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
       # Ensure the latest Phylum CLI is installed.
       - script: phylum-ci --force-install
@@ -327,9 +327,9 @@ view the [script options output][script_options] for the latest release.
       - script: |
         phylum-ci \
           -vv \
-          --lockfile requirements-dev.txt \
-          --lockfile requirements-prod.txt path/to/dependency.file \
-          --lockfile Cargo.toml \
+          --depfile requirements-dev.txt \
+          --depfile requirements-prod.txt path/to/dependency.file \
+          --depfile Cargo.toml \
           --force-analysis \
           --all-deps
 ```

--- a/docs/integrations/bitbucket_pipelines.md
+++ b/docs/integrations/bitbucket_pipelines.md
@@ -284,14 +284,14 @@ view the [script options output][script_options] for the latest release.
 
     # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
     # they can be named differently and may or may not contain strict dependencies.
-    # In these cases it is best to specify an explicit path, either with the `--lockfile`
+    # In these cases it is best to specify an explicit path, either with the `--depfile`
     # option or in a `.phylum_project` file. The easiest way to do that is with the
     # Phylum CLI, using the `phylum init` command (https://docs.phylum.io/docs/phylum_init)
     # and committing the generated `.phylum_project` file.
-    - phylum-ci --lockfile requirements-prod.txt
+    - phylum-ci --depfile requirements-prod.txt
 
     # Specify multiple explicit dependency file paths
-    - phylum-ci --lockfile requirements-prod.txt Cargo.toml path/to/dependency.file
+    - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
     # Force analysis, even when no dependency file has changed. This can be useful for
     # manifests, where the loosely specified dependencies may not change often but the
@@ -300,7 +300,7 @@ view the [script options output][script_options] for the latest release.
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
-    - phylum-ci --force-analysis --all-deps --lockfile Cargo.toml
+    - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
     # Ensure the latest Phylum CLI is installed.
     - phylum-ci --force-install
@@ -312,9 +312,9 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         -vv \
-        --lockfile requirements-dev.txt \
-        --lockfile requirements-prod.txt path/to/dependency.file \
-        --lockfile Cargo.toml \
+        --depfile requirements-dev.txt \
+        --depfile requirements-prod.txt path/to/dependency.file \
+        --depfile Cargo.toml \
         --force-analysis \
         --all-deps
 ```

--- a/docs/integrations/git_precommit.md
+++ b/docs/integrations/git_precommit.md
@@ -144,15 +144,15 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # they can be named differently and may be a manifest or a lockfile. In cases where
         # only specific dependency files are meant to be analyzed, it is best to specify
         # an explicit path to them.
-        args: [--lockfile=requirements-prod.txt]
+        args: [--depfile=requirements-prod.txt]
 
         # Specify multiple explicit dependency file paths
         args:
-          - --lockfile=requirements-prod.txt
-          - --lockfile=package-lock.json
-          - --lockfile=poetry.lock
-          - --lockfile=Cargo.toml
-          - --lockfile=path/to/dependency.file
+          - --depfile=requirements-prod.txt
+          - --depfile=package-lock.json
+          - --depfile=poetry.lock
+          - --depfile=Cargo.toml
+          - --depfile=path/to/dependency.file
 
         # Force analysis, even when no dependency file has changed. This can be useful for
         # manifests, where the loosely specified dependencies may not change often but the
@@ -161,7 +161,7 @@ with `--help` output as specified in the [Usage section of the top-level README.
 
         # Force analysis for all dependencies in a manifest file. This is especially useful
         # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
-        args: [--force-analysis, --all-deps, --lockfile=Cargo.toml]
+        args: [--force-analysis, --all-deps, --depfile=Cargo.toml]
 
         # Ensure the latest Phylum CLI is installed.
         args: [--force-install]
@@ -172,9 +172,9 @@ with `--help` output as specified in the [Usage section of the top-level README.
         # Mix and match for your specific use case.
         args:
           - -vv
-          - --lockfile=requirements-prod.txt
-          - --lockfile=path/to/dependency.file
-          - --lockfile=Cargo.toml
+          - --depfile=requirements-prod.txt
+          - --depfile=path/to/dependency.file
+          - --depfile=Cargo.toml
           - --force-analysis
           - --all-deps
 ```

--- a/docs/integrations/gitlab_ci.md
+++ b/docs/integrations/gitlab_ci.md
@@ -276,14 +276,14 @@ view the [script options output][script_options] for the latest release.
 
     # Some lockfile types (e.g., Python/pip `requirements.txt`) are ambiguous in that
     # they can be named differently and may or may not contain strict dependencies.
-    # In these cases it is best to specify an explicit path, either with the `--lockfile`
+    # In these cases it is best to specify an explicit path, either with the `--depfile`
     # option or in a `.phylum_project` file. The easiest way to do that is with the
     # Phylum CLI, using the `phylum init` command (https://docs.phylum.io/docs/phylum_init)
     # and committing the generated `.phylum_project` file.
-    - phylum-ci --lockfile requirements-prod.txt
+    - phylum-ci --depfile requirements-prod.txt
 
     # Specify multiple explicit dependency file paths
-    - phylum-ci --lockfile requirements-prod.txt Cargo.toml path/to/dependency.file
+    - phylum-ci --depfile requirements-prod.txt Cargo.toml path/to/dependency.file
 
     # Force analysis, even when no dependency file has changed. This can be useful for
     # manifests, where the loosely specified dependencies may not change often but the
@@ -292,7 +292,7 @@ view the [script options output][script_options] for the latest release.
 
     # Force analysis for all dependencies in a manifest file. This is especially useful
     # for *workspace* manifest files where there is no companion lockfile (e.g., libraries).
-    - phylum-ci --force-analysis --all-deps --lockfile Cargo.toml
+    - phylum-ci --force-analysis --all-deps --depfile Cargo.toml
 
     # Ensure the latest Phylum CLI is installed.
     - phylum-ci --force-install
@@ -305,9 +305,9 @@ view the [script options output][script_options] for the latest release.
     - |
       phylum-ci \
         -vv \
-        --lockfile requirements-dev.txt \
-        --lockfile requirements-prod.txt path/to/dependency.file \
-        --lockfile Cargo.toml \
+        --depfile requirements-dev.txt \
+        --depfile requirements-prod.txt path/to/dependency.file \
+        --depfile Cargo.toml \
         --force-analysis \
         --all-deps
 ```


### PR DESCRIPTION
phylum-dev/phylum-ci#364 introduced breaking changes. The `--lockfile`/`-l` argument was changed to `--depfile`/`-d`. This change updates the docs to match. The PR should not be merged until a `phylum-ci` release with the changes is out.
