### PR TITLE
docs: update CNAME record to point to docs.phylum.io

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -12,7 +12,7 @@ const config = {
   tagline: 'The software supply chain security company',
   favicon: 'img/favicon.ico',
 
-  url: 'https://docs-stg.phylum.io',
+  url: 'https://docs.phylum.io',
   baseUrl: '/',
   trailingSlash: false,
 
@@ -70,7 +70,7 @@ const config = {
         respectPrefersColorScheme: true,
       },
       announcementBar: {
-        content: 'Welcome to the new Phylum CLI documentation!',
+        content: 'Welcome to the new Phylum documentation!',
         textColor: '#fff',
         backgroundColor: '#3480eb',
       },

--- a/site/static/CNAME
+++ b/site/static/CNAME
@@ -1,1 +1,1 @@
-docs-stg.phylum.io
+docs.phylum.io


### PR DESCRIPTION
This PR is part of the larger coordinated effort to cutover the Phylum documentation site from being hosted on README.com to GitHub Pages.

It should not be merged until the following other tasks are complete or can happen at the same time:

* "Custom Domain" value in [GitHub repo settings](https://github.com/phylum-dev/documentation/settings/pages) changed
* https://github.com/phylum-dev/infrastructure/pull/1167
* PRs for updating URLs in other repos are merged
