### PR TITLE
fix: show correct last update time/author

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,6 +21,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
+          # Full history needed to show correct last update time/author
+          # Ref: https://github.com/facebook/docusaurus/issues/2798
+          fetch-depth: 0
 
       - name: Install local website package
         working-directory: ./site

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is the source repository for all documentation common to the Phylum platfor
 The rendered form of the documentation can be viewed at the <https://docs.phylum.io> main page.
 
 [CoC]: https://github.com/phylum-dev/documentation/blob/main/CODE_OF_CONDUCT.md
-[discord_invite]: https://discord.gg/c9QnknWxm3
+[discord_invite]: https://discord.gg/Fe6pr5eW6p
 
 ## License
 

--- a/docs/analytics/expired_author_domains.md
+++ b/docs/analytics/expired_author_domains.md
@@ -10,4 +10,4 @@ A software [package](https://en.wikipedia.org/wiki/Library_(computing)) from out
 
 ## Examples
 
-In May 2022, a security researcher noticed that the NPM package `foreach` was controlled by a single maintainer, whose email domain had expired. The researcher [bought the domain and thus gained control of `foreach`](https://www.theregister.com/2022/05/10/security_npm_email/), as above. Further, since 36,826 other NPM projects used `foreach` as a dependency, the researcher could have inserted malware into `foreach` and into 38,826 other projects through `foreach`.
+In May 2022, a security researcher noticed that the NPM package `foreach` was controlled by a single maintainer, whose email domain had expired. The researcher [bought the domain and thus gained control of `foreach`](https://www.theregister.com/2022/05/10/security_npm_email/), as above. Further, since 36,826 other NPM projects used `foreach` as a dependency, the researcher could have inserted malware into `foreach` and transitively affected 36,826 other projects.

--- a/docs/analytics/remote_exe_ref_or_run.md
+++ b/docs/analytics/remote_exe_ref_or_run.md
@@ -10,4 +10,4 @@ Executables on their own are not inherently dangerous. In fact, most software ru
 
 ## Examples
 
-In August of 2022, researchers discovered a dozen malicious packages on the PyPI repository attempting a typosquatting attack. If installed, these packages would grab a an executable payload from a malicious URL, save it to disk, and then execute the file--all from within the `setup.py`. In one observed case the executable would then recruit the host machine into a DDoS campaign against a Russian Counter-Strike server.
+In August of 2022, researchers discovered a dozen malicious packages on the PyPI repository attempting a typosquatting attack. If installed, these packages would grab an executable payload from a malicious URL, save it to disk, and then execute the file--all from within the `setup.py`. In one observed case the executable would then recruit the host machine into a DDoS campaign against a Russian Counter-Strike server.

--- a/docs/analytics/suspicious_setup_commands.md
+++ b/docs/analytics/suspicious_setup_commands.md
@@ -10,4 +10,4 @@ Because this file is blindly passed to your machine's Python interpreter upon in
 
 ## Examples
 
-One of the most prolifically distributed pieces of malware discovered so far in PyPI, the W4SP Stealer malware resulted in the publishing over 100 separate packages containing W4SP. The attackers often used the `setup.py` file as the first stage of an extremely complicated attack chain.
+One of the most prolifically distributed pieces of malware discovered so far in PyPI, the W4SP Stealer, resulted in publishing over 100 separate packages containing W4SP. The attackers often used the `setup.py` file as the first stage of an extremely complicated attack chain.

--- a/docs/support/contact_us.md
+++ b/docs/support/contact_us.md
@@ -2,4 +2,4 @@
 
 We'd love to answer your questions or provide recommendations on your unique environment! Search our documentation, contact [support](mailto:support@phylum.io) or connect with our [sales team](mailto:sales@phylum.io).
 
-Also, join us on the [Phylum Community Discord](https://discord.gg/c9QnknWxm3)!
+Also, join us on the [Phylum Community Discord](https://discord.gg/Fe6pr5eW6p)!

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -111,7 +111,7 @@ const config = {
           },
           {
             label: 'Discord',
-            href: 'https://discord.gg/c9QnknWxm3',
+            href: 'https://discord.gg/Fe6pr5eW6p',
           },
           {
             label: 'Twitter',


### PR DESCRIPTION
This PR addresses the issue of the "Last updated on" time and author being the same for every page and set to the most recent commit time/author. It modifies the git fetch depth in the `docs` workflow used for publishing the site, as detailed in this discussion: https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951.

This PR also takes the opportunity to update the Discord Phylum Community link so that it shows "Louis (lwlang)" as the inviter instead of "Bill@Phylum (bill_phylum)".

Finally, a few grammar updates were made and a few typos fixed. 