### PR TITLE
feat: add client side redirects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,11 @@ Releases happen automatically, every time there is a push to the `main` branch.
 
 ## Tips
 
-This section will be populated as the repository grows and lessons are learned.
+### Page changes
+
+If an existing published URI changes (e.g., `/analytics/original_name` --> `/analytics/new_name`), for whatever reason,
+ensure a redirect is added to ensure existing links in wild don't break. Currently, this is done by updating the
+Docusaurus `plugin-client-redirects` plugin configuration in the larger `site/docusaurus.config.js` configuration file.
 
 ## Contact
 

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -175,13 +175,13 @@ const config = {
     },
   },
 
-  // This plugin is needed due to interactions between docusaurus and webpack not
-  // handling symlinks correctly. Without it, the site won't build due to failures
-  // in following the symlinks in `docs` to their git submodules. References:
-  // https://github.com/facebook/docusaurus/issues/3272#issuecomment-876374383
-  // https://github.com/facebook/docusaurus/issues/6257
-  // https://docusaurus.io/docs/api/plugin-methods
   plugins: [
+    // This plugin is needed due to interactions between docusaurus and webpack not
+    // handling symlinks correctly. Without it, the site won't build due to failures
+    // in following the symlinks in `docs` to their git submodules. References:
+    // https://github.com/facebook/docusaurus/issues/3272#issuecomment-876374383
+    // https://github.com/facebook/docusaurus/issues/6257
+    // https://docusaurus.io/docs/api/plugin-methods
     async function (context, options) {
       return {
         name: 'webpack-configuration-plugin',
@@ -194,6 +194,65 @@ const config = {
         }
       };
     },
+
+    // This plugin ensures existing links don't break by adding client side redirect entries
+    // Ref: https://docusaurus.io/docs/api/plugins/@docusaurus/plugin-client-redirects
+    [
+      '@docusaurus/plugin-client-redirects',
+      {
+        // Add unique redirect entries here
+        redirects: [
+          {
+            from: '/docs/welcome',
+            to: '/',
+          },
+          {
+            from: '/docs/analyzing-dependencies',
+            to: '/cli/analyzing_dependencies',
+          },
+          {
+            from: '/docs/executes_code_at_remote_url_rule',
+            to: '/analytics/executes_code_at_remote_url',
+          },
+          // TODO: Enable this redirect once the page exists
+          //       https://github.com/phylum-dev/documentation/issues/83
+          // {
+          //   from: '/docs/cargo_build_file_rule',
+          //   to: '/analytics/cargo_build_file',
+          // },
+          // TODO: Enable this redirect once the page exists
+          //       https://github.com/phylum-dev/documentation/issues/86
+          // {
+          //   from: '/docs/nuget_install_scripts_rule',
+          //   to: '/analytics/nuget_install_scripts',
+          // },
+        ],
+
+        // This function seeks to account for the bulk of the changes made during the
+        // switch from Readme.com to Docusaurus SSG output hosted on GitHub Pages.
+        // It redirects from the old flat "/docs/X" namespace to the new path-based namespaces.
+        createRedirects(existingPath) {
+          // Ensure paths with the same starting elements are listed with the longest matching paths first
+          const newPathElements = [
+            '/analytics/',
+            '/cli/commands/',
+            '/cli/extensions/',
+            '/cli/',
+            '/home/',
+            '/integrations/',
+            '/knowledge_base/',
+            '/support/',
+          ];
+          for (const newPathElement of newPathElements) {
+            if (existingPath.includes(newPathElement)) {
+              return existingPath.replace(newPathElement, '/docs/');
+            }
+          }
+          // Returning a falsy value means no redirect(s) created
+          return undefined;
+        },
+      },
+    ],
   ],
 };
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@docusaurus/core": "3.0.1",
+        "@docusaurus/plugin-client-redirects": "^3.0.1",
         "@docusaurus/preset-classic": "3.0.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
@@ -2330,6 +2331,29 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/@docusaurus/plugin-client-redirects": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.0.1.tgz",
+      "integrity": "sha512-CoZapnHbV3j5jsHCa/zmKaa8+H+oagHBgg91dN5I8/3kFit/xtZPfRaznvDX49cHg2nSoV74B3VMAT+bvCmzFQ==",
+      "dependencies": {
+        "@docusaurus/core": "3.0.1",
+        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/utils-validation": "3.0.1",
+        "eta": "^2.2.0",
+        "fs-extra": "^11.1.1",
+        "lodash": "^4.17.21",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {

--- a/site/package.json
+++ b/site/package.json
@@ -15,6 +15,7 @@
   },
   "dependencies": {
     "@docusaurus/core": "3.0.1",
+    "@docusaurus/plugin-client-redirects": "3.0.1",
     "@docusaurus/preset-classic": "3.0.1",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -33,7 +33,7 @@ const sidebars = {
           link: {
             type: 'generated-index',
             title: 'Command Line Tool',
-            slug: '/cli/commands'
+            slug: '/cli/commands',
           },
           items: [
             {
@@ -113,7 +113,7 @@ const sidebars = {
         type: 'generated-index',
         title: 'Rules and Heuristics',
         description: 'Phylum analytics consist of rules and heuristics:',
-        slug: '/analytics'
+        slug: '/analytics',
       },
       items: [
         {


### PR DESCRIPTION
This change adds the official Docusaurus `plugin-client-redirects` plugin, as discussed in the https://github.com/phylum-dev/rules/pull/445 PR comments. Doing so ensures the existing links that haven't been (or can't be) changed will continue to work. These links could exist anywhere, but the known locations include:

* The main phylum.io website
* The blog.phylum.io website
* The "Learn more" links in issue card text
  * `rules`, UI, database, etc.
