### PR TITLE
Update `threat_feed.md`

### DIFF
--- a/docs/knowledge_base/threat_feed.md
+++ b/docs/knowledge_base/threat_feed.md
@@ -22,7 +22,7 @@ The Phylum threat feed provides a curated view into malware being released acros
 
 - `has_next` - `true` if there is another page available in the feed
 - `has_previous` - `true` if there is a previous page in the feed
-- `pacakges` - A list containing threat information
+- `packages` - A list containing threat information
 
 For example:
 
@@ -88,8 +88,8 @@ The threat feed API provides several parameters for interacting with the feed it
 
 | Parameter | Description |
 | --- | --- |
-| `page` | Specifies the page of the feed to retrieve |
-| `per_page` | Specifies the number of items per page (default: 25) |
+| `page` | Specifies the page of the feed to retrieve. |
+| `per_page` | Specifies the number of items per page. The default is `25` and the upper limit is `50`. |
 | `since` | Fetches items added to the feed since the given date. Must be in the form of `YYYY-MM-DD`, e.g. `2023-06-18`. |
 
 For example, if you want to limit the items per page to 3 since July 19, 2023 you would perform a `GET` request to:


### PR DESCRIPTION
This change states more clearly that the upper limit for the `per_page` parameter is `50`. It also fixes a typo.
