### PR TITLE
Bump docusaurus to v3.1.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,7 @@ Releases happen automatically, every time there is a push to the `main` branch.
 ### Page changes
 
 If an existing published URI changes (e.g., `/analytics/original_name` --> `/analytics/new_name`), for whatever reason,
-ensure a redirect is added to ensure existing links in wild don't break. Currently, this is done by updating the
+ensure a redirect is added to ensure existing links in the wild don't break. Currently, this is done by updating the
 Docusaurus `plugin-client-redirects` plugin configuration in the larger `site/docusaurus.config.js` configuration file.
 
 ## Contact

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -22,6 +22,7 @@ const config = {
   deploymentBranch: 'gh-pages',
 
   onBrokenLinks: 'throw',
+  onBrokenAnchors: 'throw',
   onBrokenMarkdownLinks: 'throw',
   onDuplicateRoutes: 'throw',
 

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "site",
       "version": "0.1.0",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-client-redirects": "3.0.1",
-        "@docusaurus/preset-classic": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/plugin-client-redirects": "3.1.0",
+        "@docusaurus/preset-classic": "3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
         "prism-react-renderer": "^2.3.1",
@@ -18,8 +18,8 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/types": "3.1.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -283,20 +283,20 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.7.tgz",
-      "integrity": "sha512-+UpDgowcmqe36d4NwqvKsyPMlOLNGMsfMmQ5WGCu+siCe3t3dfe9njrzGfdN4qq+bcNUt0+Vw6haRxBOycs4dw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.9.tgz",
+      "integrity": "sha512-5q0175NOjddqpvvzU+kDiSOAk4PfdO6FvwCWoQ6RO7rTzEe8vlo+4HVfcnAREhD4npMs0e9uZypjTwzZPCf/cw==",
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.23.5",
         "@babel/generator": "^7.23.6",
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-module-transforms": "^7.23.3",
-        "@babel/helpers": "^7.23.7",
-        "@babel/parser": "^7.23.6",
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.7",
-        "@babel/types": "^7.23.6",
+        "@babel/helpers": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -379,9 +379,9 @@
       }
     },
     "node_modules/@babel/helper-create-class-features-plugin": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.7.tgz",
-      "integrity": "sha512-xCoqR/8+BoNnXOY7RVSgv6X+o7pmT5q1d+gGcRlXYkI+9B31glE4jeejhKVpA04O1AtzOt7OSQ6VYKP5FcRl9g==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.9.tgz",
+      "integrity": "sha512-B2L9neXTIyPQoXDm+NtovPvG6VOLWnaXu3BIeVDWwdKFgG30oNa6CqVGiJPDWQwIAK49t9gnQI9c6K6RzabiKw==",
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.22.5",
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -640,13 +640,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.8.tgz",
-      "integrity": "sha512-KDqYz4PiOWvDFrdHLPhKtCThtIcKVy6avWD2oG4GEvyQ+XDZwHD4YQd+H2vNMnq2rkdxsDkU82T+Vk8U/WXHRQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.9.tgz",
+      "integrity": "sha512-87ICKgU5t5SzOT7sBMfCOZQ2rHjRU+Pcb9BoILMYz600W6DkVRLFBPwQ18gwUVvggqXivaUakpnxWQGbpywbBQ==",
       "dependencies": {
-        "@babel/template": "^7.22.15",
-        "@babel/traverse": "^7.23.7",
-        "@babel/types": "^7.23.6"
+        "@babel/template": "^7.23.9",
+        "@babel/traverse": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -730,9 +730,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
-      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.9.tgz",
+      "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1056,9 +1056,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-async-generator-functions": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.7.tgz",
-      "integrity": "sha512-PdxEpL71bJp1byMG0va5gwQcXHxuEYC/BgI/e88mGTtohbZN28O5Yit0Plkkm/dBzCF/BxmbNcses1RH1T+urA==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.9.tgz",
+      "integrity": "sha512-8Q3veQEDGe14dTYuwagbRtwxQDnytyg1JFu4/HwEMETeofocrB0U0ejBJIXoeG/t2oXZ8kzCyI0ZZfbT80VFNQ==",
       "dependencies": {
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-plugin-utils": "^7.22.5",
@@ -1392,9 +1392,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.23.3",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.3.tgz",
-      "integrity": "sha512-ZxyKGTkF9xT9YJuKQRo19ewf3pXpopuYQd8cDXqNzc3mUNbOME0RKMoZxviQk74hwzfQsEe66dE92MaZbdHKNQ==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.23.9.tgz",
+      "integrity": "sha512-KDlPRM6sLo4o1FkiSlXoAa8edLXFsKKIda779fbLrvmeuc3itnjCtaO6RrtoaANsIJANj+Vk1zqbZIMhkCAHVw==",
       "dependencies": {
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-module-transforms": "^7.23.3",
@@ -1711,15 +1711,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-runtime": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.7.tgz",
-      "integrity": "sha512-fa0hnfmiXc9fq/weK34MUV0drz2pOL/vfKWvN7Qw127hiUPabFCUMgAbYWcchRzMJit4o5ARsK/s+5h0249pLw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.9.tgz",
+      "integrity": "sha512-A7clW3a0aSjm3ONU9o2HAILSegJCYlEZmOhmBRReVtIpY/Z/p7yIZ+wR41Z+UipwdGuqwtID/V/dOdZXjwi9gQ==",
       "dependencies": {
         "@babel/helper-module-imports": "^7.22.15",
         "@babel/helper-plugin-utils": "^7.22.5",
-        "babel-plugin-polyfill-corejs2": "^0.4.7",
-        "babel-plugin-polyfill-corejs3": "^0.8.7",
-        "babel-plugin-polyfill-regenerator": "^0.5.4",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
         "semver": "^6.3.1"
       },
       "engines": {
@@ -1885,9 +1885,9 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.8.tgz",
-      "integrity": "sha512-lFlpmkApLkEP6woIKprO6DO60RImpatTQKtz4sUcDjVcK8M8mQ4sZsuxaTMNOZf0sqAq/ReYW1ZBHnOQwKpLWA==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.9.tgz",
+      "integrity": "sha512-3kBGTNBBk9DQiPoXYS0g0BYlwTQYUTifqgKTjxUwEUkduRT2QOa0FPGBJ+NROQhGyYO5BuTJwGvBnqKDykac6A==",
       "dependencies": {
         "@babel/compat-data": "^7.23.5",
         "@babel/helper-compilation-targets": "^7.23.6",
@@ -1916,7 +1916,7 @@
         "@babel/plugin-syntax-top-level-await": "^7.14.5",
         "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
         "@babel/plugin-transform-arrow-functions": "^7.23.3",
-        "@babel/plugin-transform-async-generator-functions": "^7.23.7",
+        "@babel/plugin-transform-async-generator-functions": "^7.23.9",
         "@babel/plugin-transform-async-to-generator": "^7.23.3",
         "@babel/plugin-transform-block-scoped-functions": "^7.23.3",
         "@babel/plugin-transform-block-scoping": "^7.23.4",
@@ -1938,7 +1938,7 @@
         "@babel/plugin-transform-member-expression-literals": "^7.23.3",
         "@babel/plugin-transform-modules-amd": "^7.23.3",
         "@babel/plugin-transform-modules-commonjs": "^7.23.3",
-        "@babel/plugin-transform-modules-systemjs": "^7.23.3",
+        "@babel/plugin-transform-modules-systemjs": "^7.23.9",
         "@babel/plugin-transform-modules-umd": "^7.23.3",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
         "@babel/plugin-transform-new-target": "^7.23.3",
@@ -1964,9 +1964,9 @@
         "@babel/plugin-transform-unicode-regex": "^7.23.3",
         "@babel/plugin-transform-unicode-sets-regex": "^7.23.3",
         "@babel/preset-modules": "0.1.6-no-external-plugins",
-        "babel-plugin-polyfill-corejs2": "^0.4.7",
-        "babel-plugin-polyfill-corejs3": "^0.8.7",
-        "babel-plugin-polyfill-regenerator": "^0.5.4",
+        "babel-plugin-polyfill-corejs2": "^0.4.8",
+        "babel-plugin-polyfill-corejs3": "^0.9.0",
+        "babel-plugin-polyfill-regenerator": "^0.5.5",
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
@@ -2041,9 +2041,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.9.tgz",
+      "integrity": "sha512-0CX6F+BI2s9dkUqr08KFrAIZgNFj75rdBU/DjCyYLIaV/quFjkk6T+EJ2LkZHyZTbEV4L5p97mNkUsHl2wLFAw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -2052,9 +2052,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.8.tgz",
-      "integrity": "sha512-2ZzmcDugdm0/YQKFVYsXiwUN7USPX8PM7cytpb4PFl87fM+qYPSvTZX//8tyeJB1j0YDmafBJEbl5f8NfLyuKw==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.23.9.tgz",
+      "integrity": "sha512-oeOFTrYWdWXCvXGB5orvMTJ6gCZ9I6FBjR+M38iKNXCsPxr4xT0RTdg5uz1H7QP8pp74IzPtwritEr+JscqHXQ==",
       "dependencies": {
         "core-js-pure": "^3.30.2",
         "regenerator-runtime": "^0.14.0"
@@ -2064,22 +2064,22 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
-      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
+      "integrity": "sha512-+xrD2BWLpvHKNmX2QbpdpsBaWnRxahMwJjO+KZk2JOElj5nSmKezyS1B4u+QbHMTX69t4ukm6hh9lsYQ7GHCKA==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/parser": "^7.22.15",
-        "@babel/types": "^7.22.15"
+        "@babel/code-frame": "^7.23.5",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.23.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
-      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.9.tgz",
+      "integrity": "sha512-I/4UJ9vs90OkBtY6iiiTORVMyIhJ4kAVmsKo9KFc8UOxMeUfi2hvtIBsET5u9GizXE6/GFSuKCTNfgCswuEjRg==",
       "dependencies": {
         "@babel/code-frame": "^7.23.5",
         "@babel/generator": "^7.23.6",
@@ -2087,8 +2087,8 @@
         "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.23.6",
-        "@babel/types": "^7.23.6",
+        "@babel/parser": "^7.23.9",
+        "@babel/types": "^7.23.9",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -2097,9 +2097,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.23.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
-      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
+      "version": "7.23.9",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.9.tgz",
+      "integrity": "sha512-dQjSq/7HaSjRM43FFGnv5keM2HsxpmyV1PfaSVm0nzzjwwTmjOe6J4bC8e3+pTEIgHaHj+1ZlLThRJ2auc/w1Q==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.23.4",
         "@babel/helper-validator-identifier": "^7.22.20",
@@ -2163,9 +2163,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.0.1.tgz",
-      "integrity": "sha512-CXrLpOnW+dJdSv8M5FAJ3JBwXtL6mhUWxFA8aS0ozK6jBG/wgxERk5uvH28fCeFxOGbAT9v1e9dOMo1X2IEVhQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.0.tgz",
+      "integrity": "sha512-GWudMGYA9v26ssbAWJNfgeDZk+lrudUTclLPRsmxiknEBk7UMp7Rglonhqbsf3IKHOyHkMU4Fr5jFyg5SBx9jQ==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2177,13 +2177,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
+        "@docusaurus/cssnano-preset": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
@@ -2249,9 +2249,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.0.1.tgz",
-      "integrity": "sha512-wjuXzkHMW+ig4BD6Ya1Yevx9UJadO4smNZCEljqBoQfIQrQskTswBs7lZ8InHP7mCt273a/y/rm36EZhqJhknQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.0.tgz",
+      "integrity": "sha512-ned7qsgCqSv/e7KyugFNroAfiszuxLwnvMW7gmT2Ywxb/Nyt61yIw7KHyAZCMKglOalrqnYA4gMhLUCK/mVePA==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2263,9 +2263,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.0.1.tgz",
-      "integrity": "sha512-I5L6Nk8OJzkVA91O2uftmo71LBSxe1vmOn9AMR6JRCzYeEBrqneWMH02AqMvjJ2NpMiviO+t0CyPjyYV7nxCWQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.0.tgz",
+      "integrity": "sha512-p740M+HCst1VnKKzL60Hru9xfG4EUYJDarjlEC4hHeBy9+afPmY3BNPoSHx9/8zxuYfUlv/psf7I9NvRVdmdvg==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2275,15 +2275,15 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.0.1.tgz",
-      "integrity": "sha512-ldnTmvnvlrONUq45oKESrpy+lXtbnTcTsFkOTIDswe5xx5iWJjt6eSa0f99ZaWlnm24mlojcIGoUWNCS53qVlQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.0.tgz",
+      "integrity": "sha512-D7onDz/3mgBonexWoQXPw3V2E5Bc4+jYRf9gGUUK+KoQwU8xMDaDkUUfsr7t6UBa/xox9p5+/3zwLuXOYMzGSg==",
       "dependencies": {
         "@babel/parser": "^7.22.7",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2315,12 +2315,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.0.1.tgz",
-      "integrity": "sha512-DEHpeqUDsLynl3AhQQiO7AbC7/z/lBra34jTcdYuvp9eGm01pfH1wTVq8YqWZq6Jyx0BgcVl/VJqtE9StRd9Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.0.tgz",
+      "integrity": "sha512-XUl7Z4PWlKg4l6KF05JQ3iDHQxnPxbQUqTNKvviHyuHdlalOFv6qeDAm7IbzyQPJD5VA6y4dpRbTWSqP9ClwPg==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.0.1",
+        "@docusaurus/types": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2334,15 +2334,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.0.1.tgz",
-      "integrity": "sha512-CoZapnHbV3j5jsHCa/zmKaa8+H+oagHBgg91dN5I8/3kFit/xtZPfRaznvDX49cHg2nSoV74B3VMAT+bvCmzFQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.1.0.tgz",
+      "integrity": "sha512-CuFbdciMGvtGYiIPSOpj5idsHOQUcqZWTLCmZV3ePhviekm4dRZm1+QK/BxigmSTL5ICJMGbtOQnz7bgFSWHqg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2357,17 +2357,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.0.1.tgz",
-      "integrity": "sha512-cLOvtvAyaMQFLI8vm4j26svg3ktxMPSXpuUJ7EERKoGbfpJSsgtowNHcRsaBVmfuCsRSk1HZ/yHBsUkTmHFEsg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.0.tgz",
+      "integrity": "sha512-iMa6WBaaEdYuxckvJtLcq/HQdlA4oEbCXf/OFfsYJCCULcDX7GDZpKxLF3X1fLsax3sSm5bmsU+CA0WD+R1g3A==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2388,17 +2388,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.0.1.tgz",
-      "integrity": "sha512-dRfAOA5Ivo+sdzzJGXEu33yAtvGg8dlZkvt/NEJ7nwi1F2j4LEdsxtfX2GKeETB2fP6XoGNSQnFXqa2NYGrHFg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.0.tgz",
+      "integrity": "sha512-el5GxhT8BLrsWD0qGa8Rq+Ttb/Ni6V3DGT2oAPio0qcs/mUAxeyXEAmihkvmLCnAgp6xD27Ce7dISZ5c6BXeqA==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2417,15 +2417,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.0.1.tgz",
-      "integrity": "sha512-oP7PoYizKAXyEttcvVzfX3OoBIXEmXTMzCdfmC4oSwjG4SPcJsRge3mmI6O8jcZBgUPjIzXD21bVGWEE1iu8gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.0.tgz",
+      "integrity": "sha512-9gntYQFpk+93+Xl7gYczJu8I9uWoyRLnRwS0+NUFcs9iZtHKsdqKWPRrONC9elfN3wJ9ORwTbcVzsTiB8jvYlg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2439,13 +2439,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.0.1.tgz",
-      "integrity": "sha512-09dxZMdATky4qdsZGzhzlUvvC+ilQ2hKbYF+wez+cM2mGo4qHbv8+qKXqxq0CQZyimwlAOWQLoSozIXU0g0i7g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.0.tgz",
+      "integrity": "sha512-AbvJwCVRbmQ8w9d8QXbF4Iq/ui0bjPZNYFIhtducGFnm2YQRN1mraK8mCEQb0Aq0T8SqRRvSfC/far4n/s531w==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2459,13 +2459,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.0.1.tgz",
-      "integrity": "sha512-jwseSz1E+g9rXQwDdr0ZdYNjn8leZBnKPjjQhMBEiwDoenL3JYFcNW0+p0sWoVF/f2z5t7HkKA+cYObrUh18gg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.0.tgz",
+      "integrity": "sha512-zvUOMzu9Uhz0ciqnSbtnp/5i1zEYlzarQrOXG90P3Is3efQI43p2YLW/rzSGdLb5MfQo2HvKT6Q5+tioMO045Q==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2477,13 +2477,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.0.1.tgz",
-      "integrity": "sha512-UFTDvXniAWrajsulKUJ1DB6qplui1BlKLQZjX4F7qS/qfJ+qkKqSkhJ/F4VuGQ2JYeZstYb+KaUzUzvaPK1aRQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.0.tgz",
+      "integrity": "sha512-0txshvaY8qIBdkk2UATdVcfiCLGq3KAUfuRQD2cRNgO39iIf4/ihQxH9NXcRTwKs4Q5d9yYHoix3xT6pFuEYOg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2496,13 +2496,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.0.1.tgz",
-      "integrity": "sha512-IPFvuz83aFuheZcWpTlAdiiX1RqWIHM+OH8wS66JgwAKOiQMR3+nLywGjkLV4bp52x7nCnwhNk1rE85Cpy/CIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.0.tgz",
+      "integrity": "sha512-zOWPEi8kMyyPtwG0vhyXrdbLs8fIZmY5vlbi9lUU+v8VsroO5iHmfR2V3SMsrsfOanw5oV/ciWqbxezY00qEZg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2514,16 +2514,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.0.1.tgz",
-      "integrity": "sha512-xARiWnjtVvoEniZudlCq5T9ifnhCu/GAZ5nA7XgyLfPcNpHQa241HZdsTlLtVcecEVVdllevBKOp7qknBBaMGw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.0.tgz",
+      "integrity": "sha512-TkR5vGBpUooEB9SoW42thahqqwKzfHrQQhkB+JrEGERsl4bKODSuJNle4aA4h6LSkg4IyfXOW8XOI0NIPWb9Cg==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2537,23 +2537,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.0.1.tgz",
-      "integrity": "sha512-il9m9xZKKjoXn6h0cRcdnt6wce0Pv1y5t4xk2Wx7zBGhKG1idu4IFHtikHlD0QPuZ9fizpXspXcTzjL5FXc1Gw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.0.tgz",
+      "integrity": "sha512-xGLQRFmmT9IinAGUDVRYZ54Ys28USNbA3OTXQXnSJLPr1rCY7CYnHI4XoOnKWrNnDiAI4ruMzunXWyaElUYCKQ==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/plugin-debug": "3.0.1",
-        "@docusaurus/plugin-google-analytics": "3.0.1",
-        "@docusaurus/plugin-google-gtag": "3.0.1",
-        "@docusaurus/plugin-google-tag-manager": "3.0.1",
-        "@docusaurus/plugin-sitemap": "3.0.1",
-        "@docusaurus/theme-classic": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-search-algolia": "3.0.1",
-        "@docusaurus/types": "3.0.1"
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/plugin-debug": "3.1.0",
+        "@docusaurus/plugin-google-analytics": "3.1.0",
+        "@docusaurus/plugin-google-gtag": "3.1.0",
+        "@docusaurus/plugin-google-tag-manager": "3.1.0",
+        "@docusaurus/plugin-sitemap": "3.1.0",
+        "@docusaurus/theme-classic": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-search-algolia": "3.1.0",
+        "@docusaurus/types": "3.1.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2576,22 +2576,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.0.1.tgz",
-      "integrity": "sha512-XD1FRXaJiDlmYaiHHdm27PNhhPboUah9rqIH0lMpBt5kYtsGjJzhqa27KuZvHLzOP2OEpqd2+GZ5b6YPq7Q05Q==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.0.tgz",
+      "integrity": "sha512-/+jMl2Z9O8QQxves5AtHdt91gWsEZFgOV3La/6eyKEd7QLqQUtM5fxEJ40rq9NKYjqCd1HzZ9egIMeJoWwillw==",
       "dependencies": {
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/types": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/types": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2615,17 +2615,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.0.1.tgz",
-      "integrity": "sha512-cr9TOWXuIOL0PUfuXv6L5lPlTgaphKP+22NdVBOYah5jSq5XAAulJTjfe+IfLsEG4L7lJttLbhW7LXDFSAI7Ag==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.0.tgz",
+      "integrity": "sha512-YGwEFALLIbF5ocW/Fy6Ae7tFWUOugEN3iwxTx8UkLAcLqYUboDSadesYtVBmRCEB4FVA2qoP7YaW3lu3apUPPw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.0.1",
-        "@docusaurus/module-type-aliases": "3.0.1",
-        "@docusaurus/plugin-content-blog": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/plugin-content-pages": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-common": "3.0.1",
+        "@docusaurus/mdx-loader": "3.1.0",
+        "@docusaurus/module-type-aliases": "3.1.0",
+        "@docusaurus/plugin-content-blog": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/plugin-content-pages": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-common": "3.1.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2644,18 +2644,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.0.1.tgz",
-      "integrity": "sha512-DDiPc0/xmKSEdwFkXNf1/vH1SzJPzuJBar8kMcBbDAZk/SAmo/4lf6GU2drou4Ae60lN2waix+jYWTWcJRahSA==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.0.tgz",
+      "integrity": "sha512-8cJH0ZhPsEDjq3jR3I+wHmWzVY2bXMQJ59v2QxUmsTZxbWA4u+IzccJMIJx4ooFl9J6iYynwYsFuHxyx/KUmfQ==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.0.1",
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/plugin-content-docs": "3.0.1",
-        "@docusaurus/theme-common": "3.0.1",
-        "@docusaurus/theme-translations": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
-        "@docusaurus/utils-validation": "3.0.1",
+        "@docusaurus/core": "3.1.0",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/plugin-content-docs": "3.1.0",
+        "@docusaurus/theme-common": "3.1.0",
+        "@docusaurus/theme-translations": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
+        "@docusaurus/utils-validation": "3.1.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2674,9 +2674,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.0.1.tgz",
-      "integrity": "sha512-6UrbpzCTN6NIJnAtZ6Ne9492vmPVX+7Fsz4kmp+yor3KQwA1+MCzQP7ItDNkP38UmVLnvB/cYk/IvehCUqS3dg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.0.tgz",
+      "integrity": "sha512-DApE4AbDI+WBajihxB54L4scWQhVGNZAochlC9fkbciPuFAgdRBD3NREb0rgfbKexDC/rioppu/WJA0u8tS+yA==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2686,10 +2686,11 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.0.1.tgz",
-      "integrity": "sha512-plyX2iU1tcUsF46uQ01pAd4JhexR7n0iiQ5MSnBFX6M6NSJgDYdru/i1/YNPKOnQHBoXGLHv0dNT6OAlDWNjrg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.0.tgz",
+      "integrity": "sha512-VaczOZf7+re8aFBIWnex1XENomwHdsSTkrdX43zyor7G/FY4OIsP6X28Xc3o0jiY0YdNuvIDyA5TNwOtpgkCVw==",
       "dependencies": {
+        "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "commander": "^5.1.0",
@@ -2705,11 +2706,11 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.0.1.tgz",
-      "integrity": "sha512-TwZ33Am0q4IIbvjhUOs+zpjtD/mXNmLmEgeTGuRq01QzulLHuPhaBTTAC/DHu6kFx3wDgmgpAlaRuCHfTcXv8g==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-LgZfp0D+UBqAh7PZ//MUNSFBMavmAPku6Si9x8x3V+S318IGCNJ6hUr2O29UO0oLybEWUjD5Jnj9IUN6XyZeeg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2740,9 +2741,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.0.1.tgz",
-      "integrity": "sha512-W0AxD6w6T8g6bNro8nBRWf7PeZ/nn7geEWM335qHU2DDDjHuV4UZjgUGP1AQsdcSikPrlIqTJJbKzer1lRSlIg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.0.tgz",
+      "integrity": "sha512-SfvnRLHoZ9bwTw67knkSs7IcUR0GY2SaGkpdB/J9pChrDiGhwzKNUhcieoPyPYrOWGRPk3rVNYtoy+Bc7psPAw==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2759,12 +2760,12 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.0.1.tgz",
-      "integrity": "sha512-ujTnqSfyGQ7/4iZdB4RRuHKY/Nwm58IIb+41s5tCXOv/MBU2wGAjOHq3U+AEyJ8aKQcHbxvTKJaRchNHYUVUQg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.0.tgz",
+      "integrity": "sha512-dFxhs1NLxPOSzmcTk/eeKxLY5R+U4cua22g9MsAMiRWcwFKStZ2W3/GDY0GmnJGqNS8QAQepJrxQoyxXkJNDeg==",
       "dependencies": {
-        "@docusaurus/logger": "3.0.1",
-        "@docusaurus/utils": "3.0.1",
+        "@docusaurus/logger": "3.1.0",
+        "@docusaurus/utils": "3.1.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -3507,9 +3508,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.5.tgz",
-      "integrity": "sha512-g557vgQjUUfN76MZAN/dt1z3dzcUsimuysco0KeluHgrPdJXkP/XdAURgyO2W9fZWHRtRBiVKzKn8vyOAwlG+w==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3961,9 +3962,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.1.tgz",
-      "integrity": "sha512-qxAHVjjmT7USVvrM8q6gZGaJlCK1fl4APfdAA7o8O6iXEc68G0xMNrzRkxoB/HmhhvyHnoteS/iMTiHiTcQQcg==",
+      "version": "3.16.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.16.2.tgz",
+      "integrity": "sha512-Yl/Gu5Cq4Z5s/AJ0jR37OPI1H3+z7PHz657ibyaXgMOaWvPlZ3OACN13N+7HCLPUlB0BN+8BtmrG/CqTilowBA==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -4163,27 +4164,12 @@
       }
     },
     "node_modules/babel-plugin-polyfill-corejs3": {
-      "version": "0.8.7",
-      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
-      "integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.9.0.tgz",
+      "integrity": "sha512-7nZPG1uzK2Ymhy/NbaOWTg3uibM2BmGASS4vHS4szRZAIR8R6GwA/xAujpdrXU5iyklrimWnLWU+BLF9suPTqg==",
       "dependencies": {
-        "@babel/helper-define-polyfill-provider": "^0.4.4",
-        "core-js-compat": "^3.33.1"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-polyfill-corejs3/node_modules/@babel/helper-define-polyfill-provider": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
-      "integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
-      "dependencies": {
-        "@babel/helper-compilation-targets": "^7.22.6",
-        "@babel/helper-plugin-utils": "^7.22.5",
-        "debug": "^4.1.1",
-        "lodash.debounce": "^4.0.8",
-        "resolve": "^1.14.2"
+        "@babel/helper-define-polyfill-provider": "^0.5.0",
+        "core-js-compat": "^3.34.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -4467,9 +4453,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001579",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz",
-      "integrity": "sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==",
+      "version": "1.0.30001580",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001580.tgz",
+      "integrity": "sha512-mtj5ur2FFPZcCEpXFy8ADXbDACuNFXg6mxVDqp7tqooX6l3zwm+d8EPoeOSIFRDvHs8qu7/SLFOGniULkcH2iA==",
       "funding": [
         {
           "type": "opencollective",
@@ -5716,9 +5702,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.640",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.640.tgz",
-      "integrity": "sha512-z/6oZ/Muqk4BaE7P69bXhUhpJbUM9ZJeka43ZwxsDshKtePns4mhBlh8bU5+yrnOnz3fhG82XLzGUXazOmsWnA=="
+      "version": "1.4.646",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.646.tgz",
+      "integrity": "sha512-vThkQ0JuF45qT/20KbRgM56lV7IuGt7SjhawQ719PDHzhP84KAO1WJoaxgCoAffKHK47FmVKP1Fqizx7CwK1SA=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -11605,9 +11591,9 @@
       }
     },
     "node_modules/property-information": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.0.tgz",
-      "integrity": "sha512-9t5qARVofg2xQqKtytzt+lZ4d1Qvj8t5B8fEwXK6qOfgRLgH/b13QlgEyDh033NOS31nXeFbYv7CLUDG1CeifQ==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-6.4.1.tgz",
+      "integrity": "sha512-OHYtXfu5aI2sS2LWFSN5rgJjrQ4pCy8i1jubJLe2QvMF8JJ++HXTUIVWFLfXJoaOfvYYjk2SN8J2wFUWIGXT4w==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
@@ -14159,18 +14145,18 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.89.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
-      "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
+      "version": "5.90.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.90.0.tgz",
+      "integrity": "sha512-bdmyXRCXeeNIePv6R6tGPyy20aUobw4Zy8r0LUS2EWO+U+Ke/gYDgsCh7bl5rB6jPpr4r0SZa6dPxBxLooDT3w==",
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
-        "@types/estree": "^1.0.0",
+        "@types/estree": "^1.0.5",
         "@webassemblyjs/ast": "^1.11.5",
         "@webassemblyjs/wasm-edit": "^1.11.5",
         "@webassemblyjs/wasm-parser": "^1.11.5",
         "acorn": "^8.7.1",
         "acorn-import-assertions": "^1.9.0",
-        "browserslist": "^4.14.5",
+        "browserslist": "^4.21.10",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.15.0",
         "es-module-lexer": "^1.2.1",
@@ -14184,7 +14170,7 @@
         "neo-async": "^2.6.2",
         "schema-utils": "^3.2.0",
         "tapable": "^2.1.1",
-        "terser-webpack-plugin": "^5.3.7",
+        "terser-webpack-plugin": "^5.3.10",
         "watchpack": "^2.4.0",
         "webpack-sources": "^3.2.3"
       },

--- a/site/package.json
+++ b/site/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.0.1",
-    "@docusaurus/plugin-client-redirects": "3.0.1",
-    "@docusaurus/preset-classic": "3.0.1",
+    "@docusaurus/core": "3.1.0",
+    "@docusaurus/plugin-client-redirects": "3.1.0",
+    "@docusaurus/preset-classic": "3.1.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
     "prism-react-renderer": "^2.3.1",
@@ -24,8 +24,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.0.1",
-    "@docusaurus/types": "3.0.1"
+    "@docusaurus/module-type-aliases": "3.1.0",
+    "@docusaurus/types": "3.1.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This change bumps the version of docusaurus from v3.0.1 to [v3.1.0](https://github.com/facebook/docusaurus/releases/tag/v3.1.0) and accounts for the new features found in the release. Namely, the new `onBrokenAnchors` configuration is added and set to `throw` to match the existing related settings. Additionally, a typo in `CONTRIBUTING.md` was fixed.
