### PR TITLE
ci: ensure tags are fetched in submodule update workflow

### DIFF
--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          submodules: true
+          fetch-tags: true
 
       - name: Update submodule
         run: git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"


### PR DESCRIPTION
This change is to fix the error seen during the latest
CLI release, which triggered a submodule update in this
repository. That [failed](https://github.com/phylum-dev/documentation/actions/runs/7700083785/job/20983096741)
in what appears to be an inability to access the requested
tag. The `actions/checkout` action does not fetch tags by
default.