### PR TITLE
ci: update submodules in submodule update workflow

### DIFF
--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -41,10 +41,11 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           submodules: true
-          fetch-tags: true
 
       - name: Update submodule
-        run: git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"
+        run: |
+          git submodule update --remote "ext/${REPO_NAME}"
+          git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"
 
       - name: Commit changes
         run: |

--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update submodule
         run: |
-          git submodule update --remote "ext/${REPO_NAME}"
+          git -C "ext/${REPO_NAME}" fetch origin "${TAG_NAME}"
           git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"
 
       - name: Commit changes

--- a/ext/README.md
+++ b/ext/README.md
@@ -16,7 +16,7 @@ For example, the process of adding the `phylum-dev/cli` repository's docs was:
 
 ```sh
 git submodule add ../cli.git ext/cli
-git submodule update --remote
+git submodule update --remote ext/cli
 cd docs
 ln -s ../ext/cli/docs cli
 ```
@@ -29,11 +29,15 @@ source repository instead. Updates from those remote repositories can be brought
 in with this workflow:
 
 ```sh
-# Example for updating the `cli` repo to the `v6.0.1` tag
-git -C ext/cli checkout v6.0.1
+# Example for updating the `cli` repo to the `v6.1.0` tag
+#
+# Ensure only the desired submodule is updated, to get it's latest tags
+git submodule update --remote ext/cli
+# Checkout the new tag
+git -C ext/cli checkout v6.1.0
 # Ensure changes are included for other consumers of this repo:
 git add ext/cli
-git commit -m "Update cli submodule to v6.0.1 tag"
+git commit -m "Update cli submodule to v6.1.0 tag"
 # Push the changes and create a PR
 ```
 


### PR DESCRIPTION
The change in #97 was not the solution as a manual trigger to the updated workflow resulted in the same error. Further investigation revealed that the submodule was not updated (did not have the latest commits and tags) before the workflow attempted to checkout the newly created tag.

This change accounts for that update step. It also ensures that each submodule command in the workflow and in documentation is acting on the explicitly named submodule so that other submodules (which don't exist yet but may soon) are not accidentally changed/updated.

Finally, the `actions/checkout` option to `fetch-tags` was removed since it was determined to act on the `documentation` repo itself and not any of the submodules. The `documentation` repo does not have any tags and, even if it did, they aren't needed for the submodule update workflow.
