### PR TITLE
ci: update submodules in submodule update workflow

### DIFF
--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update submodule
         run: |
-          git submodule update --remote "ext/${REPO_NAME}"
+          git -C "ext/${REPO_NAME}" fetch --all --tags
           git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"
 
       - name: Commit changes

--- a/.github/workflows/update_submodule.yml
+++ b/.github/workflows/update_submodule.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Update submodule
         run: |
-          git -C "ext/${REPO_NAME}" fetch origin "${TAG_NAME}"
+          git submodule update --remote "ext/${REPO_NAME}"
           git -C "ext/${REPO_NAME}" checkout "${TAG_NAME}"
 
       - name: Commit changes


### PR DESCRIPTION
The changes in #98 still did not work and produced the same
error as before.

This is another attempt to update the submodule in a way that
enables the desired tag to be checked out. It was verified to
work with local testing by emulating the sequence of `git`
commands used by the GitHub Actions workflow.
