### PR TITLE
Bump docusaurus to v3.2.0

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "site",
       "version": "0.1.0",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/plugin-client-redirects": "3.1.1",
-        "@docusaurus/preset-classic": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/plugin-client-redirects": "3.2.0",
+        "@docusaurus/preset-classic": "3.2.0",
         "@mdx-js/react": "^3.0.1",
         "clsx": "^2.1.0",
         "prism-react-renderer": "^2.3.1",
@@ -18,8 +18,8 @@
         "react-dom": "^18.2.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/types": "3.1.1"
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/types": "3.2.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -67,74 +67,74 @@
       }
     },
     "node_modules/@algolia/cache-browser-local-storage": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.22.1.tgz",
-      "integrity": "sha512-Sw6IAmOCvvP6QNgY9j+Hv09mvkvEIDKjYW8ow0UDDAxSXy664RBNQk3i/0nt7gvceOJ6jGmOTimaZoY1THmU7g==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-browser-local-storage/-/cache-browser-local-storage-4.23.2.tgz",
+      "integrity": "sha512-PvRQdCmtiU22dw9ZcTJkrVKgNBVAxKgD0/cfiqyxhA5+PHzA2WDt6jOmZ9QASkeM2BpyzClJb/Wr1yt2/t78Kw==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2"
       }
     },
     "node_modules/@algolia/cache-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.22.1.tgz",
-      "integrity": "sha512-TJMBKqZNKYB9TptRRjSUtevJeQVXRmg6rk9qgFKWvOy8jhCPdyNZV1nB3SKGufzvTVbomAukFR8guu/8NRKBTA=="
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-common/-/cache-common-4.23.2.tgz",
+      "integrity": "sha512-OUK/6mqr6CQWxzl/QY0/mwhlGvS6fMtvEPyn/7AHUx96NjqDA4X4+Ju7aXFQKh+m3jW9VPB0B9xvEQgyAnRPNw=="
     },
     "node_modules/@algolia/cache-in-memory": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.22.1.tgz",
-      "integrity": "sha512-ve+6Ac2LhwpufuWavM/aHjLoNz/Z/sYSgNIXsinGofWOysPilQZPUetqLj8vbvi+DHZZaYSEP9H5SRVXnpsNNw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/cache-in-memory/-/cache-in-memory-4.23.2.tgz",
+      "integrity": "sha512-rfbi/SnhEa3MmlqQvgYz/9NNJ156NkU6xFxjbxBtLWnHbpj+qnlMoKd+amoiacHRITpajg6zYbLM9dnaD3Bczw==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2"
       }
     },
     "node_modules/@algolia/client-account": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.22.1.tgz",
-      "integrity": "sha512-k8m+oegM2zlns/TwZyi4YgCtyToackkOpE+xCaKCYfBfDtdGOaVZCM5YvGPtK+HGaJMIN/DoTL8asbM3NzHonw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-account/-/client-account-4.23.2.tgz",
+      "integrity": "sha512-VbrOCLIN/5I7iIdskSoSw3uOUPF516k4SjDD4Qz3BFwa3of7D9A0lzBMAvQEJJEPHWdVraBJlGgdJq/ttmquJQ==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.22.1.tgz",
-      "integrity": "sha512-1ssi9pyxyQNN4a7Ji9R50nSdISIumMFDwKNuwZipB6TkauJ8J7ha/uO60sPJFqQyqvvI+px7RSNRQT3Zrvzieg==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-4.23.2.tgz",
+      "integrity": "sha512-lLj7irsAztGhMoEx/SwKd1cwLY6Daf1Q5f2AOsZacpppSvuFvuBrmkzT7pap1OD/OePjLKxicJS8wNA0+zKtuw==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.22.1.tgz",
-      "integrity": "sha512-IvaL5v9mZtm4k4QHbBGDmU3wa/mKokmqNBqPj0K7lcR8ZDKzUorhcGp/u8PkPC/e0zoHSTvRh7TRkGX3Lm7iOQ==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-4.23.2.tgz",
+      "integrity": "sha512-Q2K1FRJBern8kIfZ0EqPvUr3V29ICxCm/q42zInV+VJRjldAD9oTsMGwqUQ26GFMdFYmqkEfCbY4VGAiQhh22g==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.22.1.tgz",
-      "integrity": "sha512-sl+/klQJ93+4yaqZ7ezOttMQ/nczly/3GmgZXJ1xmoewP5jmdP/X/nV5U7EHHH3hCUEHeN7X1nsIhGPVt9E1cQ==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-4.23.2.tgz",
+      "integrity": "sha512-vwPsgnCGhUcHhhQG5IM27z8q7dWrN9itjdvgA6uKf2e9r7vB+WXt4OocK0CeoYQt3OGEAExryzsB8DWqdMK5wg==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.22.1.tgz",
-      "integrity": "sha512-yb05NA4tNaOgx3+rOxAmFztgMTtGBi97X7PC3jyNeGiwkAjOZc2QrdZBYyIdcDLoI09N0gjtpClcackoTN0gPA==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-4.23.2.tgz",
+      "integrity": "sha512-CxSB29OVGSE7l/iyoHvamMonzq7Ev8lnk/OkzleODZ1iBcCs3JC/XgTIKzN/4RSTrJ9QybsnlrN/bYCGufo7qw==",
       "dependencies": {
-        "@algolia/client-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/client-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/events": {
@@ -143,47 +143,65 @@
       "integrity": "sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ=="
     },
     "node_modules/@algolia/logger-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.22.1.tgz",
-      "integrity": "sha512-OnTFymd2odHSO39r4DSWRFETkBufnY2iGUZNrMXpIhF5cmFE8pGoINNPzwg02QLBlGSaLqdKy0bM8S0GyqPLBg=="
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-common/-/logger-common-4.23.2.tgz",
+      "integrity": "sha512-jGM49Q7626cXZ7qRAWXn0jDlzvoA1FvN4rKTi1g0hxKsTTSReyYk0i1ADWjChDPl3Q+nSDhJuosM2bBUAay7xw=="
     },
     "node_modules/@algolia/logger-console": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.22.1.tgz",
-      "integrity": "sha512-O99rcqpVPKN1RlpgD6H3khUWylU24OXlzkavUAMy6QZd1776QAcauE3oP8CmD43nbaTjBexZj2nGsBH9Tc0FVA==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/logger-console/-/logger-console-4.23.2.tgz",
+      "integrity": "sha512-oo+lnxxEmlhTBTFZ3fGz1O8PJ+G+8FiAoMY2Qo3Q4w23xocQev6KqDTA1JQAGPDxAewNA2VBwWOsVXeXFjrI/Q==",
       "dependencies": {
-        "@algolia/logger-common": "4.22.1"
+        "@algolia/logger-common": "4.23.2"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-4.23.2.tgz",
+      "integrity": "sha512-Q75CjnzRCDzgIlgWfPnkLtrfF4t82JCirhalXkSSwe/c1GH5pWh4xUyDOR3KTMo+YxxX3zTlrL/FjHmUJEWEcg==",
+      "dependencies": {
+        "@algolia/cache-browser-local-storage": "4.23.2",
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/cache-in-memory": "4.23.2",
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/logger-console": "4.23.2",
+        "@algolia/requester-browser-xhr": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/requester-node-http": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.22.1.tgz",
-      "integrity": "sha512-dtQGYIg6MteqT1Uay3J/0NDqD+UciHy3QgRbk7bNddOJu+p3hzjTRYESqEnoX/DpEkaNYdRHUKNylsqMpgwaEw==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-4.23.2.tgz",
+      "integrity": "sha512-TO9wLlp8+rvW9LnIfyHsu8mNAMYrqNdQ0oLF6eTWFxXfxG3k8F/Bh7nFYGk2rFAYty4Fw4XUtrv/YjeNDtM5og==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@algolia/requester-common": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.22.1.tgz",
-      "integrity": "sha512-dgvhSAtg2MJnR+BxrIFqlLtkLlVVhas9HgYKMk2Uxiy5m6/8HZBL40JVAMb2LovoPFs9I/EWIoFVjOrFwzn5Qg=="
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-common/-/requester-common-4.23.2.tgz",
+      "integrity": "sha512-3EfpBS0Hri0lGDB5H/BocLt7Vkop0bTTLVUBB844HH6tVycwShmsV6bDR7yXbQvFP1uNpgePRD3cdBCjeHmk6Q=="
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.22.1.tgz",
-      "integrity": "sha512-JfmZ3MVFQkAU+zug8H3s8rZ6h0ahHZL/SpMaSasTCGYR5EEJsCc8SI5UZ6raPN2tjxa5bxS13BRpGSBUens7EA==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-4.23.2.tgz",
+      "integrity": "sha512-SVzgkZM/malo+2SB0NWDXpnT7nO5IZwuDTaaH6SjLeOHcya1o56LSWXk+3F3rNLz2GVH+I/rpYKiqmHhSOjerw==",
       "dependencies": {
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@algolia/transporter": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.22.1.tgz",
-      "integrity": "sha512-kzWgc2c9IdxMa3YqA6TN0NW5VrKYYW/BELIn7vnLyn+U/RFdZ4lxxt9/8yq3DKV5snvoDzzO4ClyejZRdV3lMQ==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/@algolia/transporter/-/transporter-4.23.2.tgz",
+      "integrity": "sha512-GY3aGKBy+8AK4vZh8sfkatDciDVKad5rTY2S10Aefyjh7e7UGBP4zigf42qVXwU8VOPwi7l/L7OACGMOFcjB0Q==",
       "dependencies": {
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/requester-common": "4.22.1"
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/requester-common": "4.23.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2099,9 +2117,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.1.1.tgz",
-      "integrity": "sha512-2nQfKFcf+MLEM7JXsXwQxPOmQAR6ytKMZVSx7tVi9HEm9WtfwBH1fp6bn8Gj4zLUhjWKCLoysQ9/Wm+EZCQ4yQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-WTO6vW4404nhTmK9NL+95nd13I1JveFwZ8iOBYxb4xt+N2S3KzY+mm+1YtWw2vV37FbYfH+w+KrlrRaWuy5Hzw==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2113,14 +2131,13 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
+        "@docusaurus/cssnano-preset": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
-        "@slorber/static-site-generator-webpack-plugin": "^4.0.7",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@svgr/webpack": "^6.5.1",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
@@ -2141,6 +2158,7 @@
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
+        "eval": "^0.1.8",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "html-minifier-terser": "^7.2.0",
@@ -2149,6 +2167,7 @@
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
         "mini-css-extract-plugin": "^2.7.6",
+        "p-map": "^4.0.0",
         "postcss": "^8.4.26",
         "postcss-loader": "^7.3.3",
         "prompts": "^2.4.2",
@@ -2185,9 +2204,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.1.1.tgz",
-      "integrity": "sha512-LnoIDjJWbirdbVZDMq+4hwmrTl2yHDnBf9MLG9qyExeAE3ac35s4yUhJI8yyTCdixzNfKit4cbXblzzqMu4+8g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.2.0.tgz",
+      "integrity": "sha512-H88RXGUia7r/VF3XfyoA4kbwgpUZcKsObF6VvwBOP91EdArTf6lnHbJ/x8Ca79KS/zf98qaWyBGzW+5ez58Iyw==",
       "dependencies": {
         "cssnano-preset-advanced": "^5.3.10",
         "postcss": "^8.4.26",
@@ -2199,9 +2218,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.1.1.tgz",
-      "integrity": "sha512-BjkNDpQzewcTnST8trx4idSoAla6zZ3w22NqM/UMcFtvYJgmoE4layuTzlfql3VFPNuivvj7BOExa/+21y4X2Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.2.0.tgz",
+      "integrity": "sha512-Z1R1NcOGXZ8CkIJSvjvyxnuDDSlx/+1xlh20iVTw1DZRjonFmI3T3tTgk40YpXyWUYQpIgAoqqPMpuseMMdgRQ==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2211,15 +2230,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.1.1.tgz",
-      "integrity": "sha512-xN2IccH9+sv7TmxwsDJNS97BHdmlqWwho+kIVY4tcCXkp+k4QuzvWBeunIMzeayY4Fu13A6sAjHGv5qm72KyGA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.2.0.tgz",
+      "integrity": "sha512-JtkI5o6R/rJSr1Y23cHKz085aBJCvJw3AYHihJ7r+mBX+O8EuQIynG0e6/XpbSCpr7Ino0U50UtxaXcEbFwg9Q==",
       "dependencies": {
-        "@babel/parser": "^7.22.7",
-        "@babel/traverse": "^7.22.8",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2251,12 +2268,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.1.1.tgz",
-      "integrity": "sha512-xBJyx0TMfAfVZ9ZeIOb1awdXgR4YJMocIEzTps91rq+hJDFJgJaylDtmoRhUxkwuYmNK1GJpW95b7DLztSBJ3A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.2.0.tgz",
+      "integrity": "sha512-jRSp9YkvBwwNz6Xgy0RJPsnie+Ebb//gy7GdbkJ2pW2gvvlYKGib2+jSF0pfIzvyZLulfCynS1KQdvDKdSl8zQ==",
       "dependencies": {
         "@docusaurus/react-loadable": "5.5.2",
-        "@docusaurus/types": "3.1.1",
+        "@docusaurus/types": "3.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2270,15 +2287,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.1.1.tgz",
-      "integrity": "sha512-J/1Z75XkO+BmUXHW17FrCIYZQ3b0IKaJECH6yCxW5RQ8NMMJ+SZCtPtx5oYoAd0VHersNiUu+ZAxfOqbsn1jKQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.2.0.tgz",
+      "integrity": "sha512-re5bgvYOgBHmevlI8HO3fZHL7mvX2lAULr4E89n/bQ5kgekLLhsaerWrAah22ZluMZyJC2439EGjR63E9Ba6KA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2293,17 +2310,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.1.1.tgz",
-      "integrity": "sha512-ew/3VtVoG3emoAKmoZl7oKe1zdFOsI0NbcHS26kIxt2Z8vcXKCUgK9jJJrz0TbOipyETPhqwq4nbitrY3baibg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.2.0.tgz",
+      "integrity": "sha512-MABqwjSicyHmYEfQueMthPCz18JkVxhK3EGhXTSRWwReAZ0UTuw9pG6+Wo+uXAugDaIcJH28rVZSwTDINPm2bw==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2324,17 +2341,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.1.1.tgz",
-      "integrity": "sha512-lhFq4E874zw0UOH7ujzxnCayOyAt0f9YPVYSb9ohxrdCM8B4szxitUw9rIX4V9JLLHVoqIJb6k+lJJ1jrcGJ0A==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.2.0.tgz",
+      "integrity": "sha512-uuqhahmsBnirxOz+SXksnWt7+wc+iN4ntxNRH48BUgo7QRNLATWjHCgI8t6zrMJxK4o+QL9DhLaPDlFHs91B3Q==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2353,15 +2371,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.1.1.tgz",
-      "integrity": "sha512-NQHncNRAJbyLtgTim9GlEnNYsFhuCxaCNkMwikuxLTiGIPH7r/jpb7O3f3jUMYMebZZZrDq5S7om9a6rvB/YCA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.2.0.tgz",
+      "integrity": "sha512-4ofAN7JDsdb4tODO9OIrizWY5DmEJXr0eu+UDIkLqGP+gXXTahJZv8h2mlxO+lPXGXRCVBOfA14OG1hOYJVPwA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2375,13 +2393,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.1.1.tgz",
-      "integrity": "sha512-xWeMkueM9wE/8LVvl4+Qf1WqwXmreMjI5Kgr7GYCDoJ8zu4kD+KaMhrh7py7MNM38IFvU1RfrGKacCEe2DRRfQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.2.0.tgz",
+      "integrity": "sha512-p6WxtO5XZGz66y6QNQtCJwBefq4S6/w75XaXVvH1/2P9uaijvF7R+Cm2EWQZ5WsvA5wl//DFWblyDHRyVC207Q==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2395,13 +2413,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.1.1.tgz",
-      "integrity": "sha512-+q2UpWTqVi8GdlLoSlD5bS/YpxW+QMoBwrPrUH/NpvpuOi0Of7MTotsQf9JWd3hymZxl2uu1o3PIrbpxfeDFDQ==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.2.0.tgz",
+      "integrity": "sha512-//TepJTEyAZSvBwHKEbXHu9xT/VkK3wUil2ZakKvQZYfUC01uWn6A1E3toa8R7WhCy1xPUeIukqmJy1Clg8njQ==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2413,13 +2431,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.1.1.tgz",
-      "integrity": "sha512-0mMPiBBlQ5LFHTtjxuvt/6yzh8v7OxLi3CbeEsxXZpUzcKO/GC7UA1VOWUoBeQzQL508J12HTAlR3IBU9OofSw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.2.0.tgz",
+      "integrity": "sha512-3s6zxlaMMb87MW2Rxy6EnSRDs0WDEQPuHilZZH402C8kOrUnIwlhlfjWZ4ZyLDziGl/Eec/DvD0PVqj0qHRomA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2432,13 +2450,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.1.1.tgz",
-      "integrity": "sha512-d07bsrMLdDIryDtY17DgqYUbjkswZQr8cLWl4tzXrt5OR/T/zxC1SYKajzB3fd87zTu5W5klV5GmUwcNSMXQXA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.2.0.tgz",
+      "integrity": "sha512-rAKtsJ11vPHA7dTAqWCgyIy7AyFRF/lpI77Zd/4HKgqcIvIayVBvL3QtelhUazfYTLTH6ls6kQ9wjMcIFxRiGg==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2450,16 +2468,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.1.1.tgz",
-      "integrity": "sha512-iJ4hCaMmDaUqRv131XJdt/C/jJQx8UreDWTRqZKtNydvZVh/o4yXGRRFOplea1D9b/zpwL1Y+ZDwX7xMhIOTmg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.2.0.tgz",
+      "integrity": "sha512-gnWDFt6MStjLkdtt63Lzc+14EPSd8B6mzJGJp9GQMvWDUoMAUijUqpVIHYQq+DPMcI4PJZ5I2nsl5XFf1vOldA==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2473,23 +2491,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.1.1.tgz",
-      "integrity": "sha512-jG4ys/hWYf69iaN/xOmF+3kjs4Nnz1Ay3CjFLDtYa8KdxbmUhArA9HmP26ru5N0wbVWhY+6kmpYhTJpez5wTyg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.2.0.tgz",
+      "integrity": "sha512-t7tXyk8kUgT7hUqEOgSJnPs+Foem9ucuan/a9QVYaVFCDjp92Sb2FpCY8bVasAokYCjodYe2LfpAoSCj5YDYWg==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/plugin-debug": "3.1.1",
-        "@docusaurus/plugin-google-analytics": "3.1.1",
-        "@docusaurus/plugin-google-gtag": "3.1.1",
-        "@docusaurus/plugin-google-tag-manager": "3.1.1",
-        "@docusaurus/plugin-sitemap": "3.1.1",
-        "@docusaurus/theme-classic": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-search-algolia": "3.1.1",
-        "@docusaurus/types": "3.1.1"
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/plugin-debug": "3.2.0",
+        "@docusaurus/plugin-google-analytics": "3.2.0",
+        "@docusaurus/plugin-google-gtag": "3.2.0",
+        "@docusaurus/plugin-google-tag-manager": "3.2.0",
+        "@docusaurus/plugin-sitemap": "3.2.0",
+        "@docusaurus/theme-classic": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-search-algolia": "3.2.0",
+        "@docusaurus/types": "3.2.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2512,22 +2530,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.1.1.tgz",
-      "integrity": "sha512-GiPE/jbWM8Qv1A14lk6s9fhc0LhPEQ00eIczRO4QL2nAQJZXkjPG6zaVx+1cZxPFWbAsqSjKe2lqkwF3fGkQ7Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.2.0.tgz",
+      "integrity": "sha512-4oSO5BQOJ5ja7WYdL6jK1n4J96tp+VJHamdwao6Ea252sA3W3vvR0otTflG4p4XVjNZH6hlPQoi5lKW0HeRgfQ==",
       "dependencies": {
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-translations": "3.1.1",
-        "@docusaurus/types": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-translations": "3.2.0",
+        "@docusaurus/types": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2551,17 +2569,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.1.1.tgz",
-      "integrity": "sha512-38urZfeMhN70YaXkwIGXmcUcv2CEYK/2l4b05GkJPrbEbgpsIZM3Xc+Js2ehBGGZmfZq8GjjQ5RNQYG+MYzCYg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.2.0.tgz",
+      "integrity": "sha512-sFbw9XviNJJ+760kAcZCQMQ3jkNIznGqa6MQ70E5BnbP+ja36kGgPOfjcsvAcNey1H1Rkhh3p2Mhf4HVLdKVVw==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.1.1",
-        "@docusaurus/module-type-aliases": "3.1.1",
-        "@docusaurus/plugin-content-blog": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/plugin-content-pages": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-common": "3.1.1",
+        "@docusaurus/mdx-loader": "3.2.0",
+        "@docusaurus/module-type-aliases": "3.2.0",
+        "@docusaurus/plugin-content-blog": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/plugin-content-pages": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2580,18 +2598,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.1.1.tgz",
-      "integrity": "sha512-tBH9VY5EpRctVdaAhT+b1BY8y5dyHVZGFXyCHgTrvcXQy5CV4q7serEX7U3SveNT9zksmchPyct6i1sFDC4Z5g==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.2.0.tgz",
+      "integrity": "sha512-PgvF4qHoqJp8+GfqClUbTF/zYNOsz4De251IuzXon7+7FAXwvb2qmYtA2nEwyMbB7faKOz33Pxzv+y+153KS/g==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.1.1",
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/plugin-content-docs": "3.1.1",
-        "@docusaurus/theme-common": "3.1.1",
-        "@docusaurus/theme-translations": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
-        "@docusaurus/utils-validation": "3.1.1",
+        "@docusaurus/core": "3.2.0",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/plugin-content-docs": "3.2.0",
+        "@docusaurus/theme-common": "3.2.0",
+        "@docusaurus/theme-translations": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-validation": "3.2.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2610,9 +2628,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.1.1.tgz",
-      "integrity": "sha512-xvWQFwjxHphpJq5fgk37FXCDdAa2o+r7FX8IpMg+bGZBNXyWBu3MjZ+G4+eUVNpDhVinTc+j6ucL0Ain5KCGrg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.2.0.tgz",
+      "integrity": "sha512-VXzZJBuyVEmwUYyud+7IgJQEBRM6R2u/s10Rp3DOP19CBQxeKgHYTKkKhFtDeKMHDassb665kjgOi0YlJfUT6w==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2622,9 +2640,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.1.1.tgz",
-      "integrity": "sha512-grBqOLnubUecgKFXN9q3uit2HFbCxTWX4Fam3ZFbMN0sWX9wOcDoA7lwdX/8AmeL20Oc4kQvWVgNrsT8bKRvzg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.2.0.tgz",
+      "integrity": "sha512-uG3FfTkkkbZIPPNYx6xRfZHKeGyRd/inIT1cqvYt1FobFLd+7WhRXrSBqwJ9JajJjEAjNioRMVFgGofGf/Wdww==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2642,11 +2660,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.1.1.tgz",
-      "integrity": "sha512-ZJfJa5cJQtRYtqijsPEnAZoduW6sjAQ7ZCWSZavLcV10Fw0Z3gSaPKA/B4micvj2afRZ4gZxT7KfYqe5H8Cetg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.2.0.tgz",
+      "integrity": "sha512-3rgrE7iL60yV2JQivlcoxUNNTK2APmn+OHLUmTvX2pueIM8DEOCEFHpJO4MiWjFO7V/Wq3iA/W1M03JnjdugVw==",
       "dependencies": {
-        "@docusaurus/logger": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "@svgr/webpack": "^6.5.1",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2658,6 +2677,7 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5",
+        "prompts": "^2.4.2",
         "resolve-pathname": "^3.0.0",
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
@@ -2677,9 +2697,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.1.1.tgz",
-      "integrity": "sha512-eGne3olsIoNfPug5ixjepZAIxeYFzHHnor55Wb2P57jNbtVaFvij/T+MS8U0dtZRFi50QU+UPmRrXdVUM8uyMg==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.2.0.tgz",
+      "integrity": "sha512-WEQT5L2lT/tBQgDRgeZQAIi9YJBrwEILb1BuObQn1St3T/4K1gx5fWwOT8qdLOov296XLd1FQg9Ywu27aE9svw==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2696,12 +2716,13 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.1.1.tgz",
-      "integrity": "sha512-KlY4P9YVDnwL+nExvlIpu79abfEv6ZCHuOX4ZQ+gtip+Wxj0daccdReIWWtqxM/Fb5Cz1nQvUCc7VEtT8IBUAA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.2.0.tgz",
+      "integrity": "sha512-rCzMTqwNrBrEOyU8EaD1fYWdig4TDhfj+YLqB8DY68VUAqSIgbY+yshpqFKB0bznFYNBJbn0bGpvVuImQOa/vA==",
       "dependencies": {
-        "@docusaurus/logger": "3.1.1",
-        "@docusaurus/utils": "3.1.1",
+        "@docusaurus/logger": "3.2.0",
+        "@docusaurus/utils": "3.2.0",
+        "@docusaurus/utils-common": "3.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
         "tslib": "^2.6.0"
@@ -2803,9 +2824,9 @@
       }
     },
     "node_modules/@leichtgewicht/ip-codec": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
-      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.0.1",
@@ -2973,19 +2994,6 @@
         "micromark-factory-space": "^1.0.0",
         "micromark-util-character": "^1.1.0",
         "micromark-util-symbol": "^1.0.1"
-      }
-    },
-    "node_modules/@slorber/static-site-generator-webpack-plugin": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/@slorber/static-site-generator-webpack-plugin/-/static-site-generator-webpack-plugin-4.0.7.tgz",
-      "integrity": "sha512-Ug7x6z5lwrz0WqdnNFOMYrDQNTPAprvHLSh6+/fmml3qUiz6l5eq+2MzLKWtn/q5K5NpSiFsZTP/fck/3vjSxA==",
-      "dependencies": {
-        "eval": "^0.1.8",
-        "p-map": "^4.0.0",
-        "webpack-sources": "^3.2.2"
-      },
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
@@ -3485,12 +3493,11 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ=="
     },
     "node_modules/@types/react": {
-      "version": "18.2.70",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.70.tgz",
-      "integrity": "sha512-hjlM2hho2vqklPhopNkXkdkeq6Lv8WSZTpr7956zY+3WS5cfYUewtCzsJLsbW5dEv3lfSeQ4W14ZFeKC437JRQ==",
+      "version": "18.2.73",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.73.tgz",
+      "integrity": "sha512-XcGdod0Jjv84HOC7N5ziY3x+qL0AfmubvKOZ9hJjJ2yd5EE+KYjWhdOjt387e9HPheHkdggF9atTifMRtyAaRA==",
       "dependencies": {
         "@types/prop-types": "*",
-        "@types/scheduler": "*",
         "csstype": "^3.0.2"
       }
     },
@@ -3535,11 +3542,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/scheduler": {
-      "version": "0.16.8",
-      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
-      "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A=="
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -3877,24 +3879,25 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.22.1.tgz",
-      "integrity": "sha512-jwydKFQJKIx9kIZ8Jm44SdpigFwRGPESaxZBaHSV0XWN2yBJAOT4mT7ppvlrpA4UGzz92pqFnVKr/kaZXrcreg==",
+      "version": "4.23.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-4.23.2.tgz",
+      "integrity": "sha512-8aCl055IsokLuPU8BzLjwzXjb7ty9TPcUFFOk0pYOwsE5DMVhE3kwCMFtsCFKcnoPZK7oObm+H5mbnSO/9ioxQ==",
       "dependencies": {
-        "@algolia/cache-browser-local-storage": "4.22.1",
-        "@algolia/cache-common": "4.22.1",
-        "@algolia/cache-in-memory": "4.22.1",
-        "@algolia/client-account": "4.22.1",
-        "@algolia/client-analytics": "4.22.1",
-        "@algolia/client-common": "4.22.1",
-        "@algolia/client-personalization": "4.22.1",
-        "@algolia/client-search": "4.22.1",
-        "@algolia/logger-common": "4.22.1",
-        "@algolia/logger-console": "4.22.1",
-        "@algolia/requester-browser-xhr": "4.22.1",
-        "@algolia/requester-common": "4.22.1",
-        "@algolia/requester-node-http": "4.22.1",
-        "@algolia/transporter": "4.22.1"
+        "@algolia/cache-browser-local-storage": "4.23.2",
+        "@algolia/cache-common": "4.23.2",
+        "@algolia/cache-in-memory": "4.23.2",
+        "@algolia/client-account": "4.23.2",
+        "@algolia/client-analytics": "4.23.2",
+        "@algolia/client-common": "4.23.2",
+        "@algolia/client-personalization": "4.23.2",
+        "@algolia/client-search": "4.23.2",
+        "@algolia/logger-common": "4.23.2",
+        "@algolia/logger-console": "4.23.2",
+        "@algolia/recommend": "4.23.2",
+        "@algolia/requester-browser-xhr": "4.23.2",
+        "@algolia/requester-common": "4.23.2",
+        "@algolia/requester-node-http": "4.23.2",
+        "@algolia/transporter": "4.23.2"
       }
     },
     "node_modules/algoliasearch-helper": {
@@ -5655,9 +5658,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.715",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.715.tgz",
-      "integrity": "sha512-XzWNH4ZSa9BwVUQSDorPWAUQ5WGuYz7zJUNpNif40zFCiCl20t8zgylmreNmn26h5kiyw2lg7RfTmeMBsDklqg=="
+      "version": "1.4.721",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.721.tgz",
+      "integrity": "sha512-k1x2r6foI8iJOp+1qTxbbrrWMsOiHkzGBYwYigaq+apO1FSqtn44KTo3Sy69qt7CRr7149zTcsDvH7MUKsOuIQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -5745,9 +5748,9 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.4.2.tgz",
-      "integrity": "sha512-7nOqkomXZEaxUDJw21XZNtRk739QvrPSoZoRtbsEfcii00vdzZUh6zh1CQwHhrib8MdEtJfv5rJiGeb4KuV/vw=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.5.0.tgz",
+      "integrity": "sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw=="
     },
     "node_modules/escalade": {
       "version": "3.1.2",
@@ -6984,16 +6987,16 @@
       }
     },
     "node_modules/hast-util-to-jsx-runtime/node_modules/inline-style-parser": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.2.tgz",
-      "integrity": "sha512-EcKzdTHVe8wFVOGEYXiW9WmJXPjqi1T+234YpJr98RiFYKHV3cdy1+3mkTE+KHTHxFFLH51SfaGOoUdW+v7ViQ=="
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.3.tgz",
+      "integrity": "sha512-qlD8YNDqyTKTyuITrDOffsl6Tdhv+UC4hcdAVuQsK4IMQ99nSgd1MIA/Q+jQYoh9r3hVUXhYh7urSRmXPkW04g=="
     },
     "node_modules/hast-util-to-jsx-runtime/node_modules/style-to-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.5.tgz",
-      "integrity": "sha512-rDRwHtoDD3UMMrmZ6BzOW0naTjMsVZLIjsGleSKS/0Oz+cgCfAPRspaqJuE8rDzpKha/nEvnM0IF4seEAZUTKQ==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.6.tgz",
+      "integrity": "sha512-khxq+Qm3xEyZfKd/y9L3oIWQimxuc4STrQKtQn8aSDRHb8mFgpukgX1hdzfrMEW6JCjyJ8p89x+IUMVnCBI1PA==",
       "dependencies": {
-        "inline-style-parser": "0.2.2"
+        "inline-style-parser": "0.2.3"
       }
     },
     "node_modules/hast-util-to-parse5": {
@@ -13353,9 +13356,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.29.2",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.29.2.tgz",
-      "integrity": "sha512-ZiGkhUBIM+7LwkNjXYJq8svgkd+QK3UUr0wJqY4MieaezBSAIPgbSPZyIx0idM6XWK5CMzSWa8MJIzmRcB8Caw==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.0.tgz",
+      "integrity": "sha512-Y/SblUl5kEyEFzhMAQdsxVHh+utAxd4IuRNJzKywY/4uzSogh3G219jqbDDxYu4MXO9CzY3tSEqmZvW6AoEDJw==",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
         "acorn": "^8.8.2",

--- a/site/package.json
+++ b/site/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.1.1",
-    "@docusaurus/plugin-client-redirects": "3.1.1",
-    "@docusaurus/preset-classic": "3.1.1",
+    "@docusaurus/core": "3.2.0",
+    "@docusaurus/plugin-client-redirects": "3.2.0",
+    "@docusaurus/preset-classic": "3.2.0",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.0",
     "prism-react-renderer": "^2.3.1",
@@ -24,8 +24,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.1.1",
-    "@docusaurus/types": "3.1.1"
+    "@docusaurus/module-type-aliases": "3.2.0",
+    "@docusaurus/types": "3.2.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This change bumps the version of docusaurus from v3.1.1 to [v3.2.0](https://github.com/facebook/docusaurus/releases/tag/v3.2.0). There are no new features or bug fixes that need to be accounted for.
