### PR TITLE
Joe/141 create doc for python build hook rule

### DIFF
--- a/docs/analytics/base64_decoding.md
+++ b/docs/analytics/base64_decoding.md
@@ -1,0 +1,9 @@
+# Base64 Decoding
+
+## Description
+
+Base64 decoding is a common technique used in software development to interpret data encoded in the Base64 format, a method often used to transmit and store data compactly and securely. However, threat actors frequently use Base64-encoding to obscure malicious scripts, payloads, and links within open source software. This encoding allows the harmful content to evade detection by appearing as benign or irrelevant text. Malicious scripts are often dynamically executed via functions like `exec()`, where the encoded script is decoded just before execution, making the detection and static analysis more challenging.
+
+## Importance
+
+The use of Base64-decoding in the execution of encoded scripts is a significant security concern. It enables attackers to inject and execute malicious code within secure environments discreetly.

--- a/docs/analytics/cargo_build_file.md
+++ b/docs/analytics/cargo_build_file.md
@@ -8,6 +8,6 @@ In the Rust ecosystem, `build.rs` files play a crucial role in the package manag
 
 Despite their utility, `build.rs` files can pose security risks similar to those in other programming ecosystems that allow execution of arbitrary code during package installation. If a Rust crate (package) containing a malicious `build.rs` script is used, it can execute unauthorized actions, potentially compromising the user's system or data. It is therefore critical for developers to review and trust the source of any crate that includes a build script.
 
-## Example
+## Examples
 
 In August 2023, Phylum's automated risk detection identified a potential malware campaign leveraging the `build.rs` file in Rust packages. The scheme began with the release of several harmless, typosquatted packages which were later updated to include a mechanism for sending system information to a controlled Telegram channel. This early stage was crucial for uncovering the threat before it evolved into more harmful activities. For more detailed insights on this campaign, refer to [Phylum's blog post](https://blog.phylum.io/rust-malware-staged-on-crates-io/).

--- a/docs/analytics/cargo_build_file.md
+++ b/docs/analytics/cargo_build_file.md
@@ -1,0 +1,13 @@
+# Cargo Build File
+
+## Description
+
+In the Rust ecosystem, `build.rs` files play a crucial role in the package management and build process managed by Cargo, Rust’s package manager. These build scripts are executed before the rest of the build process, allowing developers to run custom code for tasks such as compiling native libraries, generating bindings, or performing other pre-build operations. This functionality is designed to enhance the flexibility and adaptability of build processes in Rust projects.
+
+## Importance
+
+Despite their utility, `build.rs` files can pose security risks similar to those in other programming ecosystems that allow execution of arbitrary code during package installation. If a Rust crate (package) containing a malicious `build.rs` script is used, it can execute unauthorized actions, potentially compromising the user's system or data. It is therefore critical for developers to review and trust the source of any crate that includes a build script.
+
+## Example
+
+In August 2023, Phylum's automated risk detection identified a potential malware campaign leveraging the `build.rs` file in Rust packages. The scheme began with the release of several harmless, typosquatted packages which were later updated to include a mechanism for sending system information to a controlled Telegram channel. This early stage was crucial for uncovering the threat before it evolved into more harmful activities. For more detailed insights on this campaign, refer to [Phylum's blog post](https://blog.phylum.io/rust-malware-staged-on-crates-io/).

--- a/docs/analytics/depends_on_malware.md
+++ b/docs/analytics/depends_on_malware.md
@@ -1,0 +1,9 @@
+# Depends on Malware
+
+## Description
+
+The Phylum [threat feed](https://docs.phylum.io/knowledge_base/threat_feed) is a curated list of packages identified by Phylum as malicious. This valuable resource is integrated into other aspects of our threat detection workflow. A common strategy among malware authors involves publishing a malicious package, followed by another package that depends on the first. This method is particularly effective for infiltrating malware into large, established software projects through transitive dependencies, especially when introduced by an external contributor. Any package that includes, as a dependency, another package previously marked as malicious by Phylum is flagged with the "depends on malware" issue.
+
+## Importance
+
+Using a package that depends on another package identified as malware poses the same level of threat as directly installing the malicious package itself.

--- a/docs/analytics/deprecated_package.md
+++ b/docs/analytics/deprecated_package.md
@@ -1,0 +1,9 @@
+# Deprecated Package
+
+## Description
+
+In the context of open source software, a deprecated software package refers to a version that is no longer supported, recommended, or maintained by its original developers. Although sometimes still accessible, using such packages is strongly discouraged due to several critical concerns.
+
+## Importance
+
+Deprecated packages should be avoided primarily because they are no longer maintained, which means they do not receive updates for bugs or security vulnerabilities. This lack of maintenance can lead to significant security risks, including compatibility issues with modern operating systems. Moreover, deprecated packages are a common target for threat actors who exploit known vulnerabilities to gain unauthorized access or cause harm, making these packages a substantial risk in any software environment.

--- a/docs/analytics/high_entropy_blobs.md
+++ b/docs/analytics/high_entropy_blobs.md
@@ -1,0 +1,9 @@
+# High Entropy Blobs
+
+## Description
+
+In the context of open source software, high entropy blobs refer to segments of data within code that exhibit high randomness, often indicative of encoded or encrypted content. These blobs are characterized by their dense and complex structure, which sets them apart from ordinary, predictable code or data. High entropy is typically a sign of obfuscation techniques used to hide sensitive information, such as encryption keys, credentials, or even embedded malicious payloads. Such encoding is designed to evade detection by concealing the true nature of the data.
+
+## Importance
+
+The presence of high entropy blobs in software can be a significant security concern. They are commonly employed by threat actors to obscure malicious code within seemingly benign software packages, making it difficult for traditional security tools to detect and analyze the embedded threats.

--- a/docs/analytics/malware_bazaar_check.md
+++ b/docs/analytics/malware_bazaar_check.md
@@ -2,7 +2,7 @@
 
 ## Description
 
-MalwareBazaar is a public database that collects and shares known malware samples, enriching them with additional intelligence for community use. At Phylum, we utilize this resource by checking hashes of all files ingested from open source packages against MalwareBazaar’s list of known malicious files. This process helps to identify and flag any components that match malware signatures, thus ensuring that these potentially harmful files are recognized before they can cause damage.
+[MalwareBazaar](https://bazaar.abuse.ch/) is a public database that collects and shares known malware samples, enriching them with additional intelligence for community use. At Phylum, we utilize this resource by checking hashes of all files ingested from open source packages against MalwareBazaar’s list of known malicious files. This process helps to identify and flag any components that match malware signatures, thus ensuring that these potentially harmful files are recognized before they can cause damage.
 
 ## Importance
 

--- a/docs/analytics/malware_bazaar_check.md
+++ b/docs/analytics/malware_bazaar_check.md
@@ -1,0 +1,9 @@
+# Malware Bazaar Check
+
+## Description
+
+MalwareBazaar is a public database that collects and shares known malware samples, enriching them with additional intelligence for community use. At Phylum, we utilize this resource by checking hashes of all files ingested from open source packages against MalwareBazaar’s list of known malicious files. This process helps to identify and flag any components that match malware signatures, thus ensuring that these potentially harmful files are recognized before they can cause damage.
+
+## Importance
+
+Identifying a package that includes a file matching a known malware sample listed in MalwareBazaar's database is a critical finding. It allows developers to further investigate the file on MalwareBazaar, where they can access detailed community-generated intelligence about the specific file.

--- a/docs/analytics/npm_security_holding.md
+++ b/docs/analytics/npm_security_holding.md
@@ -1,0 +1,9 @@
+# npm Security Holding
+
+## Description
+
+An npm security holding package, typically marked with a version `0.0.1-security`, is a placeholder version released by npm to replace a package removed from its registry due to security issues. This placeholder prevents malicious actors from reusing the original package name and serves as a notice that previous versions may have contained harmful elements and should no longer be used.
+
+## Importance
+
+The presence of a security holding package indicates that npm has deprecated the original package due to severe security vulnerabilities, making it unsafe for use. Developers discovering that they are using such a package should treat their system as potentially compromised. Immediate steps should be taken to remove the package and conduct a thorough security audit to mitigate any damage and ensure that no malicious code remains in the system.

--- a/docs/analytics/npm_security_holding.md
+++ b/docs/analytics/npm_security_holding.md
@@ -1,4 +1,4 @@
-# npm Security Holding
+# NPM Security Holding
 
 ## Description
 

--- a/docs/analytics/nuget_install_scripts.md
+++ b/docs/analytics/nuget_install_scripts.md
@@ -1,0 +1,9 @@
+# NuGet Install Scripts
+
+## Description
+
+In the NuGet package management system, install scripts such as `tools/init.ps1` and `tools/install.ps1` are PowerShell scripts executed during the installation of a NuGet package. These scripts are designed to perform setup tasks such as configuring settings, adjusting permissions, or installing additional components required by the package. This automation facilitates the seamless integration of packages into larger projects.
+
+## Importance
+
+While NuGet install scripts provide significant convenience by automating complex installation processes, they also introduce security risks by executing arbitrary PowerShell code during package installation. This can be exploited by malicious actors to execute unauthorized code, potentially leading to system compromise or data breaches. It is essential for developers to exercise caution by inspecting the source and contents of any NuGet package that includes install scripts, ensuring that they come from trustworthy sources and do not contain malicious code.

--- a/docs/analytics/python_build_hook.md
+++ b/docs/analytics/python_build_hook.md
@@ -1,0 +1,9 @@
+# Python Build Hook
+
+## Description
+
+In the Python ecosystem, a `pyproject.toml` file is used to manage build settings for Python projects. This enables the use of build hooks through various package managers like [Hatch](https://hatch.pypa.io/), [PDM](https://pdm-project.org/), or [Poetry](https://python-poetry.org). These build hooks allow developers to run custom code during the build process. This capability is particularly useful for automating build operations, customizing build steps, or integrating complex build requirements such as compiling extension modules.
+
+## Importance
+
+While build hooks offer significant flexibility and power within the Python packaging process, they also pose security risks if not handled carefully. Malicious code can be inserted into these hooks, which then executes during package installation. Such vulnerabilities make it possible for attackers to spread malware or execute arbitrary code on target systems. See [this blog post](https://blog.phylum.io/modern-python-build-hooks/) for more details.

--- a/docs/analytics/ruby_install_hooks.md
+++ b/docs/analytics/ruby_install_hooks.md
@@ -1,0 +1,9 @@
+# Ruby Install Hooks
+
+## Description
+
+In the RubyGems ecosystem, Ruby install hooks allow the execution of arbitrary code during the installation of a gem via the use of a `rubygems_plugin.rb` file. Developers can specify actions to take place either before (`Gem.pre_install`) or after (`Gem.post_install`) the installation process. This feature is intended for automation of tasks related to gem setup, such as configuring software, checking dependencies, or setting up environment variables.
+
+## Importance
+
+Install hooks in RubyGems are powerful tools that can significantly streamline the setup process for Ruby applications but come with inherent security risks. They permit the execution of arbitrary code, which can be exploited if a malicious gem or a compromised legitimate gem is installed. Therefore, it is crucial for developers to carefully manage and review any gems that utilize install hooks to prevent potential security vulnerabilities in their environments.

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -53,7 +53,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | CM0039 | Depends On Malware Rule | Package has dependency found in triaged malware table |
 | IM0040 | Decodes Hardcoded Base64 Strings | Package decodes hardcoded Base64 strings |
 | IM0041 | High Entropy Blobs | Package contains high entropy blobs |
-| IM0042 | Nuget Install Scripts Rule | Package contains scripts that will run on install |
+| IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
 | IM0043 | Cargo Build File Rule | Package contains build.rs file that will run on build and compile |
 | IM0044 | [Rubygems Install Hooks Rule](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |
 | CM0045 | [npm Security Holding Package](../analytics/npm_security_holding.md) | Package removed by npm as a security holding package |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -56,7 +56,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | IM0042 | Nuget Install Scripts Rule | Package contains scripts that will run on install |
 | IM0043 | Cargo Build File Rule | Package contains build.rs file that will run on build and compile |
 | IM0044 | Rubygems Install Hooks Rule | Package contains Ruby pre or post install hooks |
-| CM0045 | npm Security Holding Package | Package removed by npm as a security holding package |
+| CM0045 | [npm Security Holding Package](../analytics/npm_security_holding.md) | Package removed by npm as a security holding package |
 | CE0046 | [Deprecated Package](../analytics/deprecated_package.md) | Package has been deprecated |
 | IM0047 | [Python Build Hook](../analytics/python_build_hook.md) | Package contains Python build hook files |
 | HM0099 | [Basic Javascript Obfuscation](../analytics/obfuscated_javascript.md) | Package contains obfuscated Javascript |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -49,7 +49,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | HM0032 | [Exec on Remote URL](../analytics/executes_code_at_remote_url.md) | Package executes code from a remote URL |
 | HM0036 | [Webhook Exfil](../analytics/webhook_exfil.md) | Package exfiltrates data through a webhook |
 | CM0037 | [Malware Bazaar Check](../analytics/malware_bazaar_check.md) | Package contains a file whose hash is in Malware Bazaar |
-| CM0038 | Triaged Malware Rule (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
+| CM0038 | Triaged Malware (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
 | CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | [Decodes Hardcoded Base64 Strings](../analytics/base64_decoding.md) | Package decodes hardcoded Base64 strings |
 | IM0041 | [High Entropy Blobs](../analytics/high_entropy_blobs.md) | Package contains high entropy blobs |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -53,9 +53,9 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | CM0039 | [Depends On Malware](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | [Decodes Hardcoded Base64 Strings](../analytics/base64_decoding.md) | Package decodes hardcoded Base64 strings |
 | IM0041 | [High Entropy Blobs](../analytics/high_entropy_blobs.md) | Package contains high entropy blobs |
-| IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
-| IM0043 | [Cargo Build File Rule](../analytics/cargo_build_file.md) | Package contains build.rs file that will run on build and compile |
-| IM0044 | [Rubygems Install Hooks Rule](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |
+| IM0042 | [Nuget Install Scripts](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
+| IM0043 | [Cargo Build File](../analytics/cargo_build_file.md) | Package contains `build.rs` file that will run on build and compile |
+| IM0044 | [Rubygems Install Hooks](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |
 | CM0045 | [npm Security Holding Package](../analytics/npm_security_holding.md) | Package removed by npm as a security holding package |
 | CE0046 | [Deprecated Package](../analytics/deprecated_package.md) | Package has been deprecated |
 | IM0047 | [Python Build Hook](../analytics/python_build_hook.md) | Package contains Python build hook files |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -58,4 +58,5 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | IM0044 | Rubygems Install Hooks Rule | Package contains Ruby pre or post install hooks |
 | CM0045 | npm Security Holding Package | Package removed by npm as a security holding package |
 | CE0046 | Deprecated Package | Package has been deprecated |
+| IM0047 | [Python Build Hook](../analytics/python_build_hook.md) | Package contains Python build hook files |
 | HM0099 | [Basic Javascript Obfuscation](../analytics/obfuscated_javascript.md) | Package contains obfuscated Javascript |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -50,7 +50,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | HM0036 | [Webhook Exfil](../analytics/webhook_exfil.md) | Package exfiltrates data through a webhook |
 | CM0037 | [Malware Bazaar Check](../analytics/malware_bazaar_check.md) | Package contains a file whose hash is in Malware Bazaar |
 | CM0038 | Triaged Malware (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
-| CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
+| CM0039 | [Depends On Malware](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | [Decodes Hardcoded Base64 Strings](../analytics/base64_decoding.md) | Package decodes hardcoded Base64 strings |
 | IM0041 | [High Entropy Blobs](../analytics/high_entropy_blobs.md) | Package contains high entropy blobs |
 | IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -51,7 +51,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | CM0037 | Malware Bazaar Check | Package contains a file whose hash is in Malware Bazaar |
 | CM0038 | Triaged Malware Rule (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
 | CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
-| IM0040 | Decodes Hardcoded Base64 Strings | Package decodes hardcoded Base64 strings |
+| IM0040 | [Decodes Hardcoded Base64 Strings](../analytics/base64_decoding.md) | Package decodes hardcoded Base64 strings |
 | IM0041 | [High Entropy Blobs](../analytics/high_entropy_blobs.md) | Package contains high entropy blobs |
 | IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
 | IM0043 | [Cargo Build File Rule](../analytics/cargo_build_file.md) | Package contains build.rs file that will run on build and compile |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -57,6 +57,6 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | IM0043 | Cargo Build File Rule | Package contains build.rs file that will run on build and compile |
 | IM0044 | Rubygems Install Hooks Rule | Package contains Ruby pre or post install hooks |
 | CM0045 | npm Security Holding Package | Package removed by npm as a security holding package |
-| CE0046 | Deprecated Package | Package has been deprecated |
+| CE0046 | [Deprecated Package](../analytics/deprecated_package.md) | Package has been deprecated |
 | IM0047 | [Python Build Hook](../analytics/python_build_hook.md) | Package contains Python build hook files |
 | HM0099 | [Basic Javascript Obfuscation](../analytics/obfuscated_javascript.md) | Package contains obfuscated Javascript |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -55,7 +55,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | IM0041 | High Entropy Blobs | Package contains high entropy blobs |
 | IM0042 | Nuget Install Scripts Rule | Package contains scripts that will run on install |
 | IM0043 | Cargo Build File Rule | Package contains build.rs file that will run on build and compile |
-| IM0044 | Rubygems Install Hooks Rule | Package contains Ruby pre or post install hooks |
+| IM0044 | [Rubygems Install Hooks Rule](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |
 | CM0045 | [npm Security Holding Package](../analytics/npm_security_holding.md) | Package removed by npm as a security holding package |
 | CE0046 | [Deprecated Package](../analytics/deprecated_package.md) | Package has been deprecated |
 | IM0047 | [Python Build Hook](../analytics/python_build_hook.md) | Package contains Python build hook files |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -52,7 +52,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | CM0038 | Triaged Malware Rule (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
 | CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | Decodes Hardcoded Base64 Strings | Package decodes hardcoded Base64 strings |
-| IM0041 | High Entropy Blobs | Package contains high entropy blobs |
+| IM0041 | [High Entropy Blobs](../analytics/high_entropy_blobs.md) | Package contains high entropy blobs |
 | IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
 | IM0043 | [Cargo Build File Rule](../analytics/cargo_build_file.md) | Package contains build.rs file that will run on build and compile |
 | IM0044 | [Rubygems Install Hooks Rule](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -50,7 +50,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | HM0036 | [Webhook Exfil](../analytics/webhook_exfil.md) | Package exfiltrates data through a webhook |
 | CM0037 | Malware Bazaar Check | Package contains a file whose hash is in Malware Bazaar |
 | CM0038 | Triaged Malware Rule (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
-| CM0039 | Depends On Malware Rule | Package has dependency found in triaged malware table |
+| CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | Decodes Hardcoded Base64 Strings | Package decodes hardcoded Base64 strings |
 | IM0041 | High Entropy Blobs | Package contains high entropy blobs |
 | IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -48,7 +48,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | .M0031 | [Suspicious Python Setup Commands](../analytics/suspicious_setup_commands.md) | Package contains unusual commands in `setup.py` |
 | HM0032 | [Exec on Remote URL](../analytics/executes_code_at_remote_url.md) | Package executes code from a remote URL |
 | HM0036 | [Webhook Exfil](../analytics/webhook_exfil.md) | Package exfiltrates data through a webhook |
-| CM0037 | Malware Bazaar Check | Package contains a file whose hash is in Malware Bazaar |
+| CM0037 | [Malware Bazaar Check](../analytics/malware_bazaar_check.md) | Package contains a file whose hash is in Malware Bazaar |
 | CM0038 | Triaged Malware Rule (via [threat feed](../knowledge_base/threat_feed.md)) | Manually reviewed and confirmed to contain malware |
 | CM0039 | [Depends On Malware Rule](../analytics/depends_on_malware.md) | Package has dependency found in triaged malware table |
 | IM0040 | [Decodes Hardcoded Base64 Strings](../analytics/base64_decoding.md) | Package decodes hardcoded Base64 strings |

--- a/docs/knowledge_base/issue_tags.md
+++ b/docs/knowledge_base/issue_tags.md
@@ -54,7 +54,7 @@ Phylum uses tags to uniquely identify issues raised by the system. These tags ca
 | IM0040 | Decodes Hardcoded Base64 Strings | Package decodes hardcoded Base64 strings |
 | IM0041 | High Entropy Blobs | Package contains high entropy blobs |
 | IM0042 | [Nuget Install Scripts Rule](../analytics/nuget_install_scripts.md) | Package contains scripts that will run on install |
-| IM0043 | Cargo Build File Rule | Package contains build.rs file that will run on build and compile |
+| IM0043 | [Cargo Build File Rule](../analytics/cargo_build_file.md) | Package contains build.rs file that will run on build and compile |
 | IM0044 | [Rubygems Install Hooks Rule](../analytics/ruby_install_hooks.md) | Package contains Ruby pre or post install hooks |
 | CM0045 | [npm Security Holding Package](../analytics/npm_security_holding.md) | Package removed by npm as a security holding package |
 | CE0046 | [Deprecated Package](../analytics/deprecated_package.md) | Package has been deprecated |

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -240,18 +240,14 @@ const config = {
             from: '/integrations/gitlab_ci',
             to: '/phylum-ci/gitlab_ci',
           },
-          // TODO: Enable this redirect once the page exists
-          //       https://github.com/phylum-dev/documentation/issues/83
-          // {
-          //   from: '/docs/cargo_build_file_rule',
-          //   to: '/analytics/cargo_build_file',
-          // },
-          // TODO: Enable this redirect once the page exists
-          //       https://github.com/phylum-dev/documentation/issues/86
-          // {
-          //   from: '/docs/nuget_install_scripts_rule',
-          //   to: '/analytics/nuget_install_scripts',
-          // },
+          {
+            from: '/docs/cargo_build_file_rule',
+            to: '/analytics/cargo_build_file',
+          },
+          {
+            from: '/docs/nuget_install_scripts_rule',
+            to: '/analytics/nuget_install_scripts',
+          },
         ],
 
         // This function seeks to account for the bulk of the changes made during the


### PR DESCRIPTION
Added analytics docs for:
- python build file
- deprecated package
- npm security holding
- ruby install hooks
- nuget install hooks
- cargo build file
- depends on malware
- high entropy blobs
- b64 decoding
- malware bazaar

Closes #48 
Closes #141
Closes #131
Closes #93
Closes #87
Closes #86
Closes #85
Closes #84
Closes #83
Closes #82