### PR TITLE
Bump `docusaurus` to v3.4.0

### DIFF
--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,9 +8,9 @@
       "name": "site",
       "version": "0.1.0",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/plugin-client-redirects": "3.3.2",
-        "@docusaurus/preset-classic": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-client-redirects": "3.4.0",
+        "@docusaurus/preset-classic": "3.4.0",
         "@mdx-js/react": "^3.0.1",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.3.1",
@@ -18,8 +18,8 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/types": "3.3.2"
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/types": "3.4.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2132,9 +2132,9 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.3.2.tgz",
-      "integrity": "sha512-PzKMydKI3IU1LmeZQDi+ut5RSuilbXnA8QdowGeJEgU8EJjmx3rBHNT1LxQxOVqNEwpWi/csLwd9bn7rUjggPA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.4.0.tgz",
+      "integrity": "sha512-g+0wwmN2UJsBqy2fQRQ6fhXruoEa62JDeEa5d8IdTJlMoaDaEDfHh7WjwGRn4opuTQWpjAwP/fbcgyHKlE+64w==",
       "dependencies": {
         "@babel/core": "^7.23.3",
         "@babel/generator": "^7.23.3",
@@ -2146,12 +2146,12 @@
         "@babel/runtime": "^7.22.6",
         "@babel/runtime-corejs3": "^7.22.6",
         "@babel/traverse": "^7.22.8",
-        "@docusaurus/cssnano-preset": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/cssnano-preset": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "autoprefixer": "^10.4.14",
         "babel-loader": "^9.1.3",
         "babel-plugin-dynamic-import-node": "^2.3.3",
@@ -2217,9 +2217,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.3.2.tgz",
-      "integrity": "sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.4.0.tgz",
+      "integrity": "sha512-qwLFSz6v/pZHy/UP32IrprmH5ORce86BGtN0eBtG75PpzQJAzp9gefspox+s8IEOr0oZKuQ/nhzZ3xwyc3jYJQ==",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
         "postcss": "^8.4.38",
@@ -2231,9 +2231,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.3.2.tgz",
-      "integrity": "sha512-Ldu38GJ4P8g4guN7d7pyCOJ7qQugG7RVyaxrK8OnxuTlaImvQw33aDRwaX2eNmX8YK6v+//Z502F4sOZbHHCHQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.4.0.tgz",
+      "integrity": "sha512-bZwkX+9SJ8lB9kVRkXw+xvHYSMGG4bpYHKGXeXFvyVc79NMeeBSGgzd4TQLHH+DYeOJoCdl8flrFJVxlZ0wo/Q==",
       "dependencies": {
         "chalk": "^4.1.2",
         "tslib": "^2.6.0"
@@ -2243,13 +2243,13 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.3.2.tgz",
-      "integrity": "sha512-AFRxj/aOk3/mfYDPxE3wTbrjeayVRvNSZP7mgMuUlrb2UlPRbSVAFX1k2RbgAJrnTSwMgb92m2BhJgYRfptN3g==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.4.0.tgz",
+      "integrity": "sha512-kSSbrrk4nTjf4d+wtBA9H+FGauf2gCax89kV8SUSJu3qaTdSIKdWERlngsiHaCFgZ7laTJ8a67UFf+xlFPtuTw==",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -2281,11 +2281,11 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.3.2.tgz",
-      "integrity": "sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.4.0.tgz",
+      "integrity": "sha512-A1AyS8WF5Bkjnb8s+guTDuYmUiwJzNrtchebBHpc0gz0PyHJNMaybUlSrmJjHVcGrya0LKI4YcR3lBDQfXRYLw==",
       "dependencies": {
-        "@docusaurus/types": "3.3.2",
+        "@docusaurus/types": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2299,15 +2299,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.3.2.tgz",
-      "integrity": "sha512-W8ueb5PaQ06oanatL+CzE3GjqeRBTzv3MSFqEQlBa8BqLyOomc1uHsWgieE3glHsckU4mUZ6sHnOfesAtYnnew==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.4.0.tgz",
+      "integrity": "sha512-Pr8kyh/+OsmYCvdZhc60jy/FnrY6flD2TEAhl4rJxeVFxnvvRgEhoaIVX8q9MuJmaQoh6frPk94pjs7/6YgBDQ==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -2322,17 +2322,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.3.2.tgz",
-      "integrity": "sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.4.0.tgz",
+      "integrity": "sha512-vv6ZAj78ibR5Jh7XBUT4ndIjmlAxkijM3Sx5MAAzC1gyv0vupDQNhzuFg1USQmQVj3P5I6bquk12etPV3LJ+Xw==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "cheerio": "^1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
@@ -2353,18 +2353,18 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.3.2.tgz",
-      "integrity": "sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.4.0.tgz",
+      "integrity": "sha512-HkUCZffhBo7ocYheD9oZvMcDloRnGhBMOZRyVcAQRFmZPmNqSyISlXA1tQCIxW+r478fty97XXAGjNYzBjpCsg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -2383,15 +2383,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.3.2.tgz",
-      "integrity": "sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.4.0.tgz",
+      "integrity": "sha512-h2+VN/0JjpR8fIkDEAoadNjfR3oLzB+v1qSXbIAKjQ46JAHx3X22n9nqS+BWSQnTnp1AjkjSvZyJMekmcwxzxg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -2405,13 +2405,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.3.2.tgz",
-      "integrity": "sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.4.0.tgz",
+      "integrity": "sha512-uV7FDUNXGyDSD3PwUaf5YijX91T5/H9SX4ErEcshzwgzWwBtK37nUWPU3ZLJfeTavX3fycTOqk9TglpOLaWkCg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^1.2.0",
         "tslib": "^2.6.0"
@@ -2425,13 +2425,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.3.2.tgz",
-      "integrity": "sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.4.0.tgz",
+      "integrity": "sha512-mCArluxEGi3cmYHqsgpGGt3IyLCrFBxPsxNZ56Mpur0xSlInnIHoeLDH7FvVVcPJRPSQ9/MfRqLsainRw+BojA==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2443,13 +2443,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.3.2.tgz",
-      "integrity": "sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.4.0.tgz",
+      "integrity": "sha512-Dsgg6PLAqzZw5wZ4QjUYc8Z2KqJqXxHxq3vIoyoBWiLEEfigIs7wHR+oiWUQy3Zk9MIk6JTYj7tMoQU0Jm3nqA==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -2462,13 +2462,13 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.3.2.tgz",
-      "integrity": "sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.4.0.tgz",
+      "integrity": "sha512-O9tX1BTwxIhgXpOLpFDueYA9DWk69WCbDRrjYoMQtFHSkTyE7RhNgyjSPREUWJb9i+YUg3OrsvrBYRl64FCPCQ==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -2480,16 +2480,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.3.2.tgz",
-      "integrity": "sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.4.0.tgz",
+      "integrity": "sha512-+0VDvx9SmNrFNgwPoeoCha+tRoAjopwT0+pYO1xAbyLcewXSemq+eLxEa46Q1/aoOaJQ0qqHELuQM7iS2gp33Q==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -2503,23 +2503,23 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.3.2.tgz",
-      "integrity": "sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.4.0.tgz",
+      "integrity": "sha512-Ohj6KB7siKqZaQhNJVMBBUzT3Nnp6eTKqO+FXO3qu/n1hJl3YLwVKTWBg28LF7MWrKu46UuYavwMRxud0VyqHg==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/plugin-debug": "3.3.2",
-        "@docusaurus/plugin-google-analytics": "3.3.2",
-        "@docusaurus/plugin-google-gtag": "3.3.2",
-        "@docusaurus/plugin-google-tag-manager": "3.3.2",
-        "@docusaurus/plugin-sitemap": "3.3.2",
-        "@docusaurus/theme-classic": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-search-algolia": "3.3.2",
-        "@docusaurus/types": "3.3.2"
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/plugin-debug": "3.4.0",
+        "@docusaurus/plugin-google-analytics": "3.4.0",
+        "@docusaurus/plugin-google-gtag": "3.4.0",
+        "@docusaurus/plugin-google-tag-manager": "3.4.0",
+        "@docusaurus/plugin-sitemap": "3.4.0",
+        "@docusaurus/theme-classic": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-search-algolia": "3.4.0",
+        "@docusaurus/types": "3.4.0"
       },
       "engines": {
         "node": ">=18.0"
@@ -2530,22 +2530,22 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.3.2.tgz",
-      "integrity": "sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.4.0.tgz",
+      "integrity": "sha512-0IPtmxsBYv2adr1GnZRdMkEQt1YW6tpzrUPj02YxNpvJ5+ju4E13J5tB4nfdaen/tfR1hmpSPlTFPvTf4kwy8Q==",
       "dependencies": {
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/types": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/types": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -2569,17 +2569,17 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.3.2.tgz",
-      "integrity": "sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.4.0.tgz",
+      "integrity": "sha512-0A27alXuv7ZdCg28oPE8nH/Iz73/IUejVaCazqu9elS4ypjiLhK3KfzdSQBnL/g7YfHSlymZKdiOHEo8fJ0qMA==",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.3.2",
-        "@docusaurus/module-type-aliases": "3.3.2",
-        "@docusaurus/plugin-content-blog": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/plugin-content-pages": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/mdx-loader": "3.4.0",
+        "@docusaurus/module-type-aliases": "3.4.0",
+        "@docusaurus/plugin-content-blog": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/plugin-content-pages": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -2598,18 +2598,18 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.3.2.tgz",
-      "integrity": "sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.4.0.tgz",
+      "integrity": "sha512-aiHFx7OCw4Wck1z6IoShVdUWIjntC8FHCw9c5dR8r3q4Ynh+zkS8y2eFFunN/DL6RXPzpnvKCg3vhLQYJDmT9Q==",
       "dependencies": {
         "@docsearch/react": "^3.5.2",
-        "@docusaurus/core": "3.3.2",
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/plugin-content-docs": "3.3.2",
-        "@docusaurus/theme-common": "3.3.2",
-        "@docusaurus/theme-translations": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-validation": "3.3.2",
+        "@docusaurus/core": "3.4.0",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/plugin-content-docs": "3.4.0",
+        "@docusaurus/theme-common": "3.4.0",
+        "@docusaurus/theme-translations": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-validation": "3.4.0",
         "algoliasearch": "^4.18.0",
         "algoliasearch-helper": "^3.13.3",
         "clsx": "^2.0.0",
@@ -2628,9 +2628,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.3.2.tgz",
-      "integrity": "sha512-bPuiUG7Z8sNpGuTdGnmKl/oIPeTwKr0AXLGu9KaP6+UFfRZiyWbWE87ti97RrevB2ffojEdvchNujparR3jEZQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.4.0.tgz",
+      "integrity": "sha512-zSxCSpmQCCdQU5Q4CnX/ID8CSUUI3fvmq4hU/GNP/XoAWtXo9SAVnM3TzpU8Gb//H3WCsT8mJcTfyOk3d9ftNg==",
       "dependencies": {
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -2640,9 +2640,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.3.2.tgz",
-      "integrity": "sha512-5p201S7AZhliRxTU7uMKtSsoC8mgPA9bs9b5NQg1IRdRxJfflursXNVsgc3PcMqiUTul/v1s3k3rXXFlRE890w==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.4.0.tgz",
+      "integrity": "sha512-4jcDO8kXi5Cf9TcyikB/yKmz14f2RZ2qTRerbHAsS+5InE9ZgSLBNLsewtFTcTOXSVcbU3FoGOzcNWAmU1TR0A==",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "@types/history": "^4.7.11",
@@ -2660,12 +2660,12 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.3.2.tgz",
-      "integrity": "sha512-f4YMnBVymtkSxONv4Y8js3Gez9IgHX+Lcg6YRMOjVbq8sgCcdYK1lf6SObAuz5qB/mxiSK7tW0M9aaiIaUSUJg==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.4.0.tgz",
+      "integrity": "sha512-fRwnu3L3nnWaXOgs88BVBmG1yGjcQqZNHG+vInhEa2Sz2oQB+ZjbEMO5Rh9ePFpZ0YDiDUhpaVjwmS+AU2F14g==",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
         "@svgr/webpack": "^8.1.0",
         "escape-string-regexp": "^4.0.0",
         "file-loader": "^6.2.0",
@@ -2682,6 +2682,7 @@
         "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
+        "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
       },
       "engines": {
@@ -2697,9 +2698,9 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.3.2.tgz",
-      "integrity": "sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.4.0.tgz",
+      "integrity": "sha512-NVx54Wr4rCEKsjOH5QEVvxIqVvm+9kh7q8aYTU5WzUU9/Hctd6aTrcZ3G0Id4zYJ+AeaG5K5qHA4CY5Kcm2iyQ==",
       "dependencies": {
         "tslib": "^2.6.0"
       },
@@ -2716,15 +2717,17 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.3.2.tgz",
-      "integrity": "sha512-itDgFs5+cbW9REuC7NdXals4V6++KifgVMzoGOOOSIifBQw+8ULhy86u5e1lnptVL0sv8oAjq2alO7I40GR7pA==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.4.0.tgz",
+      "integrity": "sha512-hYQ9fM+AXYVTWxJOT1EuNaRnrR2WGpRdLDQG07O8UOpsvCPWUVOeo26Rbm0JWY2sGLfzAb+tvJ62yF+8F+TV0g==",
       "dependencies": {
-        "@docusaurus/logger": "3.3.2",
-        "@docusaurus/utils": "3.3.2",
-        "@docusaurus/utils-common": "3.3.2",
+        "@docusaurus/logger": "3.4.0",
+        "@docusaurus/utils": "3.4.0",
+        "@docusaurus/utils-common": "3.4.0",
+        "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
+        "lodash": "^4.17.21",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3351,9 +3354,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.1.tgz",
-      "integrity": "sha512-ej0phymbFLoCB26dbbq5PGScsf2JAJ4IJHjG10LalgUV36XKTmA4GdA+PVllKvRk0sEKt64X8975qFnkSi0hqA==",
+      "version": "4.19.3",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.3.tgz",
+      "integrity": "sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -3452,9 +3455,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.12.12",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.12.tgz",
-      "integrity": "sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==",
+      "version": "20.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.13.0.tgz",
+      "integrity": "sha512-FM6AOb3khNkNIXPnHFDYaHerSv8uN22C91z098AnGccVu+Pcdhi+pNUFDi0iLmPIsVE0JBD0KVS7mzUYt4nRzQ==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -3901,9 +3904,9 @@
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.20.0",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.20.0.tgz",
-      "integrity": "sha512-6EVhAmVug0+hdRHWbubF7hLHHhLoQ8NjLk6iS6d4k5chWawpS5EDexrF6Jx/hPZvUKIeNrzsbTpjAkcvrjNLHg==",
+      "version": "3.21.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.21.0.tgz",
+      "integrity": "sha512-hjVOrL15I3Y3K8xG0icwG1/tWE+MocqBrhW6uVBWpU+/kVEMK0BnM2xdssj6mZM61eJ4iRxHR0djEI3ENOpR8w==",
       "dependencies": {
         "@algolia/events": "^4.0.1"
       },
@@ -4389,9 +4392,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001623",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001623.tgz",
-      "integrity": "sha512-X/XhAVKlpIxWPpgRTnlgZssJrF0m6YtRA0QDWgsBNT12uZM6LPRydR7ip405Y3t1LamD8cP2TZFEDZFBf5ApcA==",
+      "version": "1.0.30001625",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001625.tgz",
+      "integrity": "sha512-4KE9N2gcRH+HQhpeiRZXd+1niLB/XNLAhSy4z7fI8EzcbcPoAqjNInxVHTiTwWfTIV4w096XG8OtCOCQQKPv3w==",
       "funding": [
         {
           "type": "opencollective",
@@ -4535,9 +4538,9 @@
       }
     },
     "node_modules/chrome-trace-event": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
-      "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.4.tgz",
+      "integrity": "sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==",
       "engines": {
         "node": ">=6.0"
       }
@@ -5290,9 +5293,9 @@
       "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug=="
     },
     "node_modules/debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
+      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5653,9 +5656,9 @@
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.783",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.783.tgz",
-      "integrity": "sha512-bT0jEz/Xz1fahQpbZ1D7LgmPYZ3iHVY39NcWWro1+hA2IvjiPeaXtfSqrQ+nXjApMvQRE2ASt1itSLRrebHMRQ=="
+      "version": "1.4.787",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.787.tgz",
+      "integrity": "sha512-d0EFmtLPjctczO3LogReyM2pbBiiZbnsKnGF+cdZhsYzHm/A0GV7W94kqzLD8SN4O3f3iHlgLUChqghgyznvCQ=="
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -11773,9 +11776,9 @@
       }
     },
     "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.1.tgz",
-      "integrity": "sha512-ZvFw1KWS3GVyYBYb7qkmRM/WwL2TQQBxgCK62rlvm4WpVQ23Nb4tYjApUlfjrEGvOs7KHEsmyUn75OHZrJMWPw==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.2.2.tgz",
+      "integrity": "sha512-vjJi4vQDasD8t0kMpxe+9URAcgbSuASqoj/Wuk3MawTk97LYa2KfdHreAkd1G/pmPLMvzZEw7/OsydADNemerQ==",
       "engines": {
         "node": ">= 12.13.0"
       }
@@ -12515,9 +12518,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sax": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.3.0.tgz",
-      "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA=="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
     },
     "node_modules/scheduler": {
       "version": "0.23.2",

--- a/site/package.json
+++ b/site/package.json
@@ -14,9 +14,9 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.3.2",
-    "@docusaurus/plugin-client-redirects": "3.3.2",
-    "@docusaurus/preset-classic": "3.3.2",
+    "@docusaurus/core": "3.4.0",
+    "@docusaurus/plugin-client-redirects": "3.4.0",
+    "@docusaurus/preset-classic": "3.4.0",
     "@mdx-js/react": "^3.0.1",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.3.1",
@@ -24,8 +24,8 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.3.2",
-    "@docusaurus/types": "3.3.2"
+    "@docusaurus/module-type-aliases": "3.4.0",
+    "@docusaurus/types": "3.4.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This change bumps the version of docusaurus from v3.3.2 to [v3.4.0](https://github.com/facebook/docusaurus/releases/tag/v3.4.0). There are no new features or bug fixes that need to be accounted for. The changes were tested locally by successfully building and serving the site.
