### PR TITLE
update policy documentation for v1

### DIFF
--- a/docs/knowledge_base/policy_basics.md
+++ b/docs/knowledge_base/policy_basics.md
@@ -3,21 +3,25 @@
 This is a basic policy using an `issue` rule to block any HIGH/CRITICAL issues.
 
 ```rego
-# This is effectively the name of the policy.
-# It must be "policy".
-package policy
+# METADATA
+# title: Limit risk
+# description: |
+#   Block issues based on risk level.
+package policy.v1
 
 import data.phylum.level
-import future.keywords.contains
-import future.keywords.if
+import rego.v1
 
 # METADATA
-# scope: rule
-# schemas:
-#   - data.issue: schema.issue
-issue contains "risk level cannot exceed medium" if {
-    data.issue.severity > level.MEDIUM
+# title: risk level cannot exceed medium
+deny contains issue if {
+    some issue in data.issues
+    issue.severity > level.MEDIUM
 }
 ```
 
-The `issue` rule will contain the specified text when the `if` statement is `true`. `OPA` iterates through the job input data evaluating the expression against the severity and the level.
+The `package policy.v1` line must be present. This is how OPA finds the policy's rules.
+
+The `deny` rule will contain the specified issue when the `if` statement is `true`. `OPA` iterates through the job input data evaluating the expression against the severity level of every issue in the job.
+
+The `title` field from the metadata comment above the rule will be associated with the failure in the output from Phylum.


### PR DESCRIPTION
This PR updates the policy documentation to reflect the new `policy.v1` format. The previous format still works, but the new format is preferred.

There's currently an issue with the policy SDK zip where the root element is missing. I'm pretty sure it was unintentional and there isn't a trick to making the opa CLI load data with a prefix. It should be like this one:

[constants.json](https://github.com/user-attachments/files/15537760/constants.json)


## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
