### PR TITLE
docs: expose Jenkins integration doc and disable banner

### DIFF
--- a/docs/integrations/integrations_overview.md
+++ b/docs/integrations/integrations_overview.md
@@ -14,6 +14,7 @@ The current Continuous Integration (CI) platforms/environments supported are:
 | GitLab CI | [Documentation][gitlab_docs] |
 | Azure Pipelines | [Documentation][azure_docs] |
 | Bitbucket Pipelines | [Documentation][bb_pipelines_docs] |
+| Jenkins Pipelines | [Documentation][jenkins_docs] |
 | CircleCI Orb | [Orb Registry][circleci_orb_registry] |
 
 Other integrations include:
@@ -34,6 +35,7 @@ Other integrations include:
 [gitlab_docs]: ../phylum-ci/gitlab_ci.md
 [azure_docs]: ../phylum-ci/azure_pipelines.md
 [bb_pipelines_docs]: ../phylum-ci/bitbucket_pipelines.md
+[jenkins_docs]: ../phylum-ci/jenkins.md
 [precommit_docs]: ../phylum-ci/git_precommit.md
 [dazz_docs]: ../integrations/dazz.md
 [sophos_docs]: ../integrations/sophos.md

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -75,11 +75,11 @@ const config = {
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },
-      announcementBar: {
-        content: 'Welcome to the new Phylum documentation!',
-        textColor: '#fff',
-        backgroundColor: '#3480eb',
-      },
+      // announcementBar: {
+      //   content: 'Welcome to the new Phylum documentation!',
+      //   textColor: '#fff',
+      //   backgroundColor: '#3480eb',
+      // },
       navbar: {
         title: 'Phylum Docs',
         logo: {

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -75,6 +75,7 @@ const config = {
         disableSwitch: false,
         respectPrefersColorScheme: true,
       },
+      /* To add a temporary site announcement bar, uncomment the following lines and change the content */
       // announcementBar: {
       //   content: 'Welcome to the new Phylum documentation!',
       //   textColor: '#fff',

--- a/site/sidebars.js
+++ b/site/sidebars.js
@@ -75,6 +75,7 @@ const sidebars = {
         'phylum-ci/github_actions',
         'integrations/github_app',
         'phylum-ci/gitlab_ci',
+        'phylum-ci/jenkins',
         'integrations/netskope',
         'integrations/snyk',
         'integrations/sophos',


### PR DESCRIPTION
The site banner section was intentionally commented out and left in so the format would not need to be looked up for future updates.
