### PR TITLE
docs: enable 'groovy' code formatting

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -151,6 +151,7 @@ const config = {
         // When there are aliases, use the name of the first one in the list containing the entry you actually use.
         additionalLanguages: [
           'bash',
+          'groovy',
           'javascript',
           'json',
           'python',


### PR DESCRIPTION
This is what the docs look like currently:

<img width="984" alt="image" src="https://github.com/phylum-dev/documentation/assets/18729796/06e54ed2-fc77-484d-9c39-357f7656f1e8">

---

This is what the docs look like with the change in this PR:

<img width="984" alt="image" src="https://github.com/phylum-dev/documentation/assets/18729796/a04b8dc6-7012-4d35-902a-38eb5ccd12f2">

