### PR TITLE
add docs for batch endpoint

### DIFF
--- a/docs/knowledge_base/threat_feed.md
+++ b/docs/knowledge_base/threat_feed.md
@@ -221,7 +221,7 @@ curl -X POST -H "Content-Type: application/json" -d '[
 ["npm", "lodash", "4.17.21"],
 ["pypi", "requests", "2.32.3"],
 ["cargo", "serde", "1.0.203"]
-]' http://localhost:3000/batch -H "Authorization: Bearer $PHYLUM_API"
+]' https://threats.phylum.io/batch -H "Authorization: Bearer $PHYLUM_API"
 ```
 
 Response:


### PR DESCRIPTION
Adds docs for new `/batch` threat feed end point. Also adds docs about top level key additions to single package end point.

Note that I will update the example in the docs with one that actually returns slightly more interesting results after this gets deployed and I can run it against prod instead of staging.