### PR TITLE
add replace-registry-host=never

### DIFF
--- a/docs/package_firewall/npm.md
+++ b/docs/package_firewall/npm.md
@@ -29,6 +29,7 @@ If Phylum's default [policy] is sufficient, you can remove all instances of
 Custom NPM registries can be configured with npm:
 
 ```sh
+npm config set replace-registry-host never
 npm config set registry https://<PHYLUM_GROUP>:<PHYLUM_API_KEY>@npm.phylum.io/
 ```
 


### PR DESCRIPTION
For NPM packages, the dependency firewall proxies the available package metadata but not the package content. In the returned metadata, the tarball location is pointing at the regular registry.npmjs.org location. If you don't set `replace-registry-host`, the [default value of `'registry.npmjs.org'`](https://github.com/npm/cli/blob/7788ef20aff336c95836e64997a7264913924c4b/workspaces/arborist/lib/arborist/index.js#L83-L85) will cause the NPM CLI to ["fix" the URL](https://github.com/npm/cli/blob/4e81a6a4106e4e125b0eefda042b75cfae0a5f23/workspaces/arborist/lib/arborist/reify.js#L844-L848) that we intentionally didn't change, resulting in 404 errors when trying to download the package.

## Checklist

- [ ] Does this PR have an associated issue (i.e., `closes #<issueNum>` in description above)?
- [ ] Have you ensured that you have met the expected acceptance criteria?
