### PR TITLE
Add redirect for trivial_package

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -250,6 +250,10 @@ const config = {
             from: '/docs/nuget_install_scripts_rule',
             to: '/analytics/nuget_install_scripts',
           },
+          {
+            from: '/docs/trivial_package',
+            to: '/analytics/minimal_code',
+          },
         ],
 
         // This function seeks to account for the bulk of the changes made during the


### PR DESCRIPTION
This change is a result of a broken link during a live demo and due to a change on 25 OCT 2023 in the `rules` repo where the `trivial_package` rule was renamed to `minimal_code`.

This change has been built and tested locally.
