### PR TITLE
docs: remove YouTube footer link

### DIFF
--- a/docs/knowledge_base/policy_development.md
+++ b/docs/knowledge_base/policy_development.md
@@ -143,7 +143,7 @@ Dependencies that are ignored via the `ignored_packages` parameter are filtered 
 
 The policy transforms your threat model into a description of why the job is being blocked. There are multiple ways to define why a job should be blocked.
 
-The `METADATA` block contains OPA [Annotations](https://www.openpolicyagent.org/docs/latest/annotations/) which correlate to the schema and can be used for type checking.
+The `METADATA` block contains OPA [Annotations](https://www.openpolicyagent.org/docs/latest/policy-language/#annotations) which correlate to the schema and can be used for type checking.
 
 ### Blocking an issue
 

--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -129,10 +129,6 @@ const config = {
             href: 'https://github.com/phylum-dev',
           },
           {
-            label: 'YouTube',
-            href: 'https://www.youtube.com/@phylum_io',
-          },
-          {
             label: 'LinkedIn',
             href: 'https://www.linkedin.com/company/phylum-io',
           },


### PR DESCRIPTION
This change removes the YouTube link in the footer of the site since it no longer exists. Also updated a broken OPA Annotations link after checking for bad links with <https://www.deadlinkchecker.com/>
