### PR TITLE
Explain the effect of current job on monitoring

### DIFF
--- a/docs/knowledge_base/continuous_monitoring.md
+++ b/docs/knowledge_base/continuous_monitoring.md
@@ -4,9 +4,17 @@ Phylum Continuous Monitoring ensures the accuracy of package issue data without 
 
 ## How It Works
 
-The Phylum platform monitors for new issues that impact dependencies in your project and will re-run your policy when one is found. If that issue violates your policy, we will fire off any configured [notifications] and also unsuppress the package if you previously had it suppressed, so you can address the newly found issue.
+The Phylum platform monitors for new issues that impact dependencies in your project's current job (see below for details) and will re-run your policy when one is found. If that issue violates your policy, we will fire off any configured [notifications] and also unsuppress the package if you previously had it suppressed, so you can address the newly found issue.
 
 [notifications]: ../knowledge_base/notifications.md
+
+### Current job
+
+A project's current job is the latest job that has been submitted with the project's default label. The default label can be set "Preferences" tab of the project in the Phylum App or [with the Phylum CLI][project_update].
+
+If no default label has been set, the project's current job will be the latest job submitted, regardless of label.
+
+[project_update]: https://docs.phylum.io/cli/commands/phylum_project_update
 
 ## How to Activate
 

--- a/docs/knowledge_base/continuous_monitoring.md
+++ b/docs/knowledge_base/continuous_monitoring.md
@@ -8,12 +8,13 @@ The Phylum platform monitors for new issues that impact dependencies in your pro
 
 [notifications]: ../knowledge_base/notifications.md
 
-### Current job
+### Current Job
 
-A project's current job is the latest job that has been submitted with the project's default label. The default label can be set "Preferences" tab of the project in the Phylum App or [with the Phylum CLI][project_update].
+A project's current job is the latest job that has been submitted with the project's default label. The default label can be set from the "Preferences" tab of the project in the [Phylum UI][phylum_ui] or [with the Phylum CLI][project_update].
 
 If no default label has been set, the project's current job will be the latest job submitted, regardless of label.
 
+[phylum_ui]: https://app.phylum.io
 [project_update]: https://docs.phylum.io/cli/commands/phylum_project_update
 
 ## How to Activate


### PR DESCRIPTION
The current job concept is explained directly on the continuous monitoring page since this is where the impact is most clearly seen.

This PR should be the final change needed for the [default label story](https://github.com/phylum-dev/roadmap/issues/271#issuecomment-2419674094)
