### PR TITLE
Bump `docusaurus` to v3.8.1

### DIFF
--- a/site/docusaurus.config.js
+++ b/site/docusaurus.config.js
@@ -30,6 +30,9 @@ const config = {
     // Enable all Docusaurus Faster features
     // Ref: https://docusaurus.io/blog/releases/3.6#adoption-strategy
     experimental_faster: true,
+    // Enable all Docusaurus v4 Future Flags
+    // Ref: https://docusaurus.io/blog/releases/3.8#future-flags
+    v4: true
   },
 
   i18n: {

--- a/site/package-lock.json
+++ b/site/package-lock.json
@@ -8,10 +8,10 @@
       "name": "site",
       "version": "0.1.0",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/faster": "3.7.0",
-        "@docusaurus/plugin-client-redirects": "3.7.0",
-        "@docusaurus/preset-classic": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/faster": "3.8.1",
+        "@docusaurus/plugin-client-redirects": "3.8.1",
+        "@docusaurus/preset-classic": "3.8.1",
         "@mdx-js/react": "^3.1.0",
         "clsx": "^2.1.1",
         "prism-react-renderer": "^2.4.1",
@@ -19,8 +19,8 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "3.7.0",
-        "@docusaurus/types": "3.7.0"
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -2472,9 +2472,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.1.tgz",
-      "integrity": "sha512-JLp3POui4S1auhDR0n8wHd/zTOWmMsmK3nQd3hhL6FhWPaox5W7j1se6zXOG/aP07wV2ww0lxbKYGwbBszOtfQ==",
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@csstools/postcss-is-pseudo-class/-/postcss-is-pseudo-class-5.0.3.tgz",
+      "integrity": "sha512-jS/TY4SpG4gszAtIg7Qnf3AS2pjcUM5SzxpApOrlndMeGhIbaTzWBzzP/IApXoNWEW7OhcjkRT48jnAUIFXhAQ==",
       "funding": [
         {
           "type": "github",
@@ -3130,9 +3130,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.7.0.tgz",
-      "integrity": "sha512-0H5uoJLm14S/oKV3Keihxvh8RV+vrid+6Gv+2qhuzbqHanawga8tYnsdpjEyt36ucJjqlby2/Md2ObWjA02UXQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.8.1.tgz",
+      "integrity": "sha512-3brkJrml8vUbn9aeoZUlJfsI/GqyFcDgQJwQkmBtclJgWDEQBKKeagZfOgx0WfUQhagL1sQLNW0iBdxnI863Uw==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3145,8 +3145,8 @@
         "@babel/runtime": "^7.25.9",
         "@babel/runtime-corejs3": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3156,31 +3156,30 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.7.0.tgz",
-      "integrity": "sha512-CUUT9VlSGukrCU5ctZucykvgCISivct+cby28wJwCC/fkQFgAHRp/GKv2tx38ZmXb7nacrKzFTcp++f9txUYGg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.8.1.tgz",
+      "integrity": "sha512-/z4V0FRoQ0GuSLToNjOSGsk6m2lQUG4FRn8goOVoZSRsTrU8YR2aJacX5K3RG18EaX9b+52pN4m1sL3MQZVsQA==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/cssnano-preset": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/cssnano-preset": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "babel-loader": "^9.2.1",
-        "clean-css": "^5.3.2",
+        "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
-        "css-loader": "^6.8.1",
+        "css-loader": "^6.11.0",
         "css-minimizer-webpack-plugin": "^5.0.1",
         "cssnano": "^6.1.2",
         "file-loader": "^6.2.0",
         "html-minifier-terser": "^7.2.0",
-        "mini-css-extract-plugin": "^2.9.1",
+        "mini-css-extract-plugin": "^2.9.2",
         "null-loader": "^4.0.1",
-        "postcss": "^8.4.26",
-        "postcss-loader": "^7.3.3",
-        "postcss-preset-env": "^10.1.0",
-        "react-dev-utils": "^12.0.1",
+        "postcss": "^8.5.4",
+        "postcss-loader": "^7.3.4",
+        "postcss-preset-env": "^10.2.1",
         "terser-webpack-plugin": "^5.3.9",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
@@ -3200,18 +3199,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.7.0.tgz",
-      "integrity": "sha512-b0fUmaL+JbzDIQaamzpAFpTviiaU4cX3Qz8cuo14+HGBCwa0evEK0UYCBFY3n4cLzL8Op1BueeroUD2LYAIHbQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.8.1.tgz",
+      "integrity": "sha512-ENB01IyQSqI2FLtOzqSI3qxG2B/jP4gQPahl2C3XReiLebcVh5B5cB9KYFvdoOqOWPyr5gXK4sjgTKv7peXCrA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.7.0",
-        "@docusaurus/bundler": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/babel": "3.8.1",
+        "@docusaurus/bundler": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3219,19 +3218,19 @@
         "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
         "core-js": "^3.31.1",
-        "del": "^6.1.1",
         "detect-port": "^1.5.1",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
+        "execa": "5.1.1",
         "fs-extra": "^11.1.1",
         "html-tags": "^3.3.1",
         "html-webpack-plugin": "^5.6.0",
         "leven": "^3.1.0",
         "lodash": "^4.17.21",
+        "open": "^8.4.0",
         "p-map": "^4.0.0",
         "prompts": "^2.4.2",
-        "react-dev-utils": "^12.0.1",
         "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0",
         "react-loadable-ssr-addon-v5-slorber": "^1.0.1",
@@ -3240,7 +3239,7 @@
         "react-router-dom": "^5.3.4",
         "semver": "^7.5.4",
         "serve-handler": "^6.1.6",
-        "shelljs": "^0.8.5",
+        "tinypool": "^1.0.2",
         "tslib": "^2.6.0",
         "update-notifier": "^6.0.2",
         "webpack": "^5.95.0",
@@ -3261,13 +3260,13 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.7.0.tgz",
-      "integrity": "sha512-X9GYgruZBSOozg4w4dzv9uOz8oK/EpPVQXkp0MM6Tsgp/nRIU9hJzJ0Pxg1aRa3xCeEQTOimZHcocQFlLwYajQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.8.1.tgz",
+      "integrity": "sha512-G7WyR2N6SpyUotqhGznERBK+x84uyhfMQM2MmDLs88bw4Flom6TY46HzkRkSEzaP9j80MbTN8naiL1fR17WQug==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
-        "postcss": "^8.4.38",
+        "postcss": "^8.5.4",
         "postcss-sort-media-queries": "^5.2.0",
         "tslib": "^2.6.0"
       },
@@ -3276,13 +3275,13 @@
       }
     },
     "node_modules/@docusaurus/faster": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.7.0.tgz",
-      "integrity": "sha512-d+7uyOEs3SBk38i2TL79N6mFaP7J4knc5lPX/W9od+jplXZhnDdl5ZMh2u2Lg7JxGV/l33Bd7h/xwv4mr21zag==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/faster/-/faster-3.8.1.tgz",
+      "integrity": "sha512-XYrj3qnTm+o2d5ih5drCq9s63GJoM8vZ26WbLG5FZhURsNxTSXgHJcx11Qo7nWPUStCQkuqk1HvItzscCUnd4A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.7.0",
-        "@rspack/core": "1.2.0-alpha.0",
+        "@docusaurus/types": "3.8.1",
+        "@rspack/core": "^1.3.15",
         "@swc/core": "^1.7.39",
         "@swc/html": "^1.7.39",
         "browserslist": "^4.24.2",
@@ -3298,212 +3297,10 @@
         "@docusaurus/types": "*"
       }
     },
-    "node_modules/@docusaurus/faster/node_modules/@module-federation/error-codes": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.8.4.tgz",
-      "integrity": "sha512-55LYmrDdKb4jt+qr8qE8U3al62ZANp3FhfVaNPOaAmdTh0jHdD8M3yf5HKFlr5xVkVO4eV/F/J2NCfpbh+pEXQ==",
-      "license": "MIT"
-    },
-    "node_modules/@docusaurus/faster/node_modules/@module-federation/runtime": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.8.4.tgz",
-      "integrity": "sha512-yZeZ7z2Rx4gv/0E97oLTF3V6N25vglmwXGgoeju/W2YjsFvWzVtCDI7zRRb0mJhU6+jmSM8jP1DeQGbea/AiZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/error-codes": "0.8.4",
-        "@module-federation/sdk": "0.8.4"
-      }
-    },
-    "node_modules/@docusaurus/faster/node_modules/@module-federation/runtime-tools": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.8.4.tgz",
-      "integrity": "sha512-fjVOsItJ1u5YY6E9FnS56UDwZgqEQUrWFnouRiPtK123LUuqUI9FH4redZoKWlE1PB0ir1Z3tnqy8eFYzPO38Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.8.4",
-        "@module-federation/webpack-bundler-runtime": "0.8.4"
-      }
-    },
-    "node_modules/@docusaurus/faster/node_modules/@module-federation/sdk": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.8.4.tgz",
-      "integrity": "sha512-waABomIjg/5m1rPDBWYG4KUhS5r7OUUY7S+avpaVIY/tkPWB3ibRDKy2dNLLAMaLKq0u+B1qIdEp4NIWkqhqpg==",
-      "license": "MIT",
-      "dependencies": {
-        "isomorphic-rslog": "0.0.6"
-      }
-    },
-    "node_modules/@docusaurus/faster/node_modules/@module-federation/webpack-bundler-runtime": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.8.4.tgz",
-      "integrity": "sha512-HggROJhvHPUX7uqBD/XlajGygMNM1DG0+4OAkk8MBQe4a18QzrRNzZt6XQbRTSG4OaEoyRWhQHvYD3Yps405tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime": "0.8.4",
-        "@module-federation/sdk": "0.8.4"
-      }
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-rtmDScjtGUxv1zA1m3jXecuX2LsgNp4aWaAjOowHasoO1YqfHK0fMyprCiPowTjoHtpZ7Xt/tnMhii0GlGIITQ==",
-      "license": "MIT",
-      "optionalDependencies": {
-        "@rspack/binding-darwin-arm64": "1.2.0-alpha.0",
-        "@rspack/binding-darwin-x64": "1.2.0-alpha.0",
-        "@rspack/binding-linux-arm64-gnu": "1.2.0-alpha.0",
-        "@rspack/binding-linux-arm64-musl": "1.2.0-alpha.0",
-        "@rspack/binding-linux-x64-gnu": "1.2.0-alpha.0",
-        "@rspack/binding-linux-x64-musl": "1.2.0-alpha.0",
-        "@rspack/binding-win32-arm64-msvc": "1.2.0-alpha.0",
-        "@rspack/binding-win32-ia32-msvc": "1.2.0-alpha.0",
-        "@rspack/binding-win32-x64-msvc": "1.2.0-alpha.0"
-      }
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-darwin-arm64": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-EPprIe6BrkJ9XuWL5HBXJFaH4vvt5C2kBTvyu+t5E3wacyH9A0gIDaMOEmH30Kt3zl4B07OCBC1nCiJ1sTtimw==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-darwin-x64": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-ACwdgWg0V9j0o3gs1wvhqRJ4xui82L+Fii9Fa74az7P974iWO0ZHw4QIUaO5r434+v9OWMqpyBRN1M7cBrx3GA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-arm64-gnu": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-Ex9SviDikz9E36R4I5si/626FsYOJ35l1Lb+DCRUijjjsvoq4k8Shi8csyBfubR+JZ1M0uOXjJftu1Gm5z8Q0Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-arm64-musl": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-U320xZmTcTwQ0BR8yIzE1L4olMCqzYkT3VFjXPR6iok/Mj0xjfk/SiKhLoZml473qQrHSGaFJ321cp02zgTFJg==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-x64-gnu": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-GNur7VXJ29NtJhY8PYgv3Fv1Zxbx0XZhDUj/+7Wp40CAXRFsLgXScZIRh2U30TECYaihboZ7BD+xugv8MQPDoA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-linux-x64-musl": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-0IdswzpG9+sgxvGu7KTwSeqfV0hvciaHMoZvGklfZa2txpcUqAg4ASp7uxrNaUo+G2a1fTUMOtP9351Cnl8DBg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-arm64-msvc": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-FcFgoWGjSrCfJwDZY5bDA2aO02l5BP7qdyW6ehjwBiMxNZyeSbGvKz3jXl5TtTHR1IgdLzi9kEJkTPYLLMiE1A==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-ia32-msvc": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-cZYFJw6DKCaPPz9VDJPndZ9KSp+/eedgt11Mv8OTpq+MJTUjB2HjtcjqJh8xxVcp3IuwvSMndTkC69WWt/4feA==",
-      "cpu": [
-        "ia32"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/binding-win32-x64-msvc": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-gfOqb/rq5716NV+Vbk5MteBhV4VhJeSoh2+dRQjdy4EN1wPZ+Uebs9ORVrT9uRjY3JrPn/5PkAHJXtgaOA9Uyg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
-    },
-    "node_modules/@docusaurus/faster/node_modules/@rspack/core": {
-      "version": "1.2.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.2.0-alpha.0.tgz",
-      "integrity": "sha512-YiD0vFDj+PfHs3ZqJwPNhTYyVTb4xR6FpOI5WJ4jJHV4lgdErS+RChTCPhf1xeqxfuTSSnFA7UeqosLhBuNSqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@module-federation/runtime-tools": "0.8.4",
-        "@rspack/binding": "1.2.0-alpha.0",
-        "@rspack/lite-tapable": "1.0.1",
-        "caniuse-lite": "^1.0.30001616"
-      },
-      "engines": {
-        "node": ">=16.0.0"
-      },
-      "peerDependencies": {
-        "@swc/helpers": ">=0.5.1"
-      },
-      "peerDependenciesMeta": {
-        "@swc/helpers": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@docusaurus/logger": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.7.0.tgz",
-      "integrity": "sha512-z7g62X7bYxCYmeNNuO9jmzxLQG95q9QxINCwpboVcNff3SJiHJbGrarxxOVMVmAh1MsrSfxWkVGv4P41ktnFsA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.8.1.tgz",
+      "integrity": "sha512-2wjeGDhKcExEmjX8k1N/MRDiPKXGF2Pg+df/bDDPnnJWHXnVEZxXj80d6jcxp1Gpnksl0hF8t/ZQw9elqj2+ww==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3514,21 +3311,21 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.7.0.tgz",
-      "integrity": "sha512-OFBG6oMjZzc78/U3WNPSHs2W9ZJ723ewAcvVJaqS0VgyeUfmzUV8f1sv+iUHA0DtwiR5T5FjOxj6nzEE8LY6VA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.8.1.tgz",
+      "integrity": "sha512-DZRhagSFRcEq1cUtBMo4TKxSNo/W6/s44yhr8X+eoXqCLycFQUylebOMPseHi5tc4fkGJqwqpWJLz6JStU9L4w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
         "estree-util-value-to-estree": "^3.0.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
-        "image-size": "^1.0.2",
+        "image-size": "^2.0.2",
         "mdast-util-mdx": "^3.0.0",
         "mdast-util-to-string": "^4.0.0",
         "rehype-raw": "^7.0.0",
@@ -3553,17 +3350,17 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.7.0.tgz",
-      "integrity": "sha512-g7WdPqDNaqA60CmBrr0cORTrsOit77hbsTj7xE2l71YhBn79sxdm7WMK7wfhcaafkbpIh7jv5ef5TOpf1Xv9Lg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.8.1.tgz",
+      "integrity": "sha512-6xhvAJiXzsaq3JdosS7wbRt/PwEPWHr9eM4YNYqVlbgG1hSK3uQDXTVvQktasp3VO6BmfYWPozueLWuj4gB+vg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.7.0",
+        "@docusaurus/types": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
         "@types/react-router-dom": "*",
-        "react-helmet-async": "npm:@slorber/react-helmet-async@*",
+        "react-helmet-async": "npm:@slorber/react-helmet-async@1.3.0",
         "react-loadable": "npm:@docusaurus/react-loadable@6.0.0"
       },
       "peerDependencies": {
@@ -3572,16 +3369,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-client-redirects": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.7.0.tgz",
-      "integrity": "sha512-6B4XAtE5ZVKOyhPgpgMkb7LwCkN+Hgd4vOnlbwR8nCdTQhLjz8MHbGlwwvZ/cay2SPNRX5KssqKAlcHVZP2m8g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-client-redirects/-/plugin-client-redirects-3.8.1.tgz",
+      "integrity": "sha512-F+86R7PBn6VNgy/Ux8w3ZRypJGJEzksbejQKlbTC8u6uhBUhfdXWkDp6qdOisIoW0buY5nLqucvZt1zNJzhJhA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "eta": "^2.2.0",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
@@ -3596,24 +3393,24 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.7.0.tgz",
-      "integrity": "sha512-EFLgEz6tGHYWdPU0rK8tSscZwx+AsyuBW/r+tNig2kbccHYGUJmZtYN38GjAa3Fda4NU+6wqUO5kTXQSRBQD3g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.8.1.tgz",
+      "integrity": "sha512-vNTpMmlvNP9n3hGEcgPaXyvTljanAKIUkuG9URQ1DeuDup0OR7Ltvoc8yrmH+iMZJbcQGhUJF+WjHLwuk8HSdw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "cheerio": "1.0.0-rc.12",
         "feed": "^4.2.2",
         "fs-extra": "^11.1.1",
         "lodash": "^4.17.21",
-        "reading-time": "^1.5.0",
+        "schema-dts": "^1.1.2",
         "srcset": "^4.0.0",
         "tslib": "^2.6.0",
         "unist-util-visit": "^5.0.0",
@@ -3630,25 +3427,26 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.7.0.tgz",
-      "integrity": "sha512-GXg5V7kC9FZE4FkUZA8oo/NrlRb06UwuICzI6tcbzj0+TVgjq/mpUXXzSgKzMS82YByi4dY2Q808njcBCyy6tQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.8.1.tgz",
+      "integrity": "sha512-oByRkSZzeGNQByCMaX+kif5Nl2vmtj2IHQI2fWjCfCootsdKZDPFLonhIp5s3IGJO7PLUfe0POyw0Xh/RrGXJA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/module-type-aliases": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
+        "schema-dts": "^1.1.2",
         "tslib": "^2.6.0",
         "utility-types": "^3.10.0",
         "webpack": "^5.88.1"
@@ -3662,16 +3460,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.7.0.tgz",
-      "integrity": "sha512-YJSU3tjIJf032/Aeao8SZjFOrXJbz/FACMveSMjLyMH4itQyZ2XgUIzt4y+1ISvvk5zrW4DABVT2awTCqBkx0Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.8.1.tgz",
+      "integrity": "sha512-a+V6MS2cIu37E/m7nDJn3dcxpvXb6TvgdNI22vJX8iUTp8eoMoPa0VArEbWvCxMY/xdC26WzNv4wZ6y0iIni/w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3684,17 +3482,33 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.7.0.tgz",
-      "integrity": "sha512-Qgg+IjG/z4svtbCNyTocjIwvNTNEwgRjSXXSJkKVG0oWoH0eX/HAPiu+TS1HBwRPQV+tTYPWLrUypYFepfujZA==",
+    "node_modules/@docusaurus/plugin-css-cascade-layers": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.8.1.tgz",
+      "integrity": "sha512-VQ47xRxfNKjHS5ItzaVXpxeTm7/wJLFMOPo1BkmoMG4Cuz4nuI+Hs62+RMk1OqVog68Swz66xVPK8g9XTrBKRw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
+        "tslib": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@docusaurus/plugin-debug": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.8.1.tgz",
+      "integrity": "sha512-nT3lN7TV5bi5hKMB7FK8gCffFTBSsBsAfV84/v293qAmnHOyg1nr9okEw8AiwcO3bl9vije5nsUvP0aRl2lpaw==",
+      "license": "MIT",
+      "dependencies": {
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
         "fs-extra": "^11.1.1",
-        "react-json-view-lite": "^1.2.0",
+        "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3705,27 +3519,15 @@
         "react-dom": "^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@docusaurus/plugin-debug/node_modules/react-json-view-lite": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-1.5.0.tgz",
-      "integrity": "sha512-nWqA1E4jKPklL2jvHWs6s+7Na0qNgw9HCP6xehdQJeg6nPBTFZgGwyko9Q0oj+jQWKTTVRS30u0toM5wiuL3iw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "react": "^16.13.1 || ^17.0.0 || ^18.0.0"
-      }
-    },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.7.0.tgz",
-      "integrity": "sha512-otIqiRV/jka6Snjf+AqB360XCeSv7lQC+DKYW+EUZf6XbuE8utz5PeUQ8VuOcD8Bk5zvT1MC4JKcd5zPfDuMWA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.8.1.tgz",
+      "integrity": "sha512-Hrb/PurOJsmwHAsfMDH6oVpahkEGsx7F8CWMjyP/dw1qjqmdS9rcV1nYCGlM8nOtD3Wk/eaThzUB5TSZsGz+7Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3737,14 +3539,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.7.0.tgz",
-      "integrity": "sha512-M3vrMct1tY65ModbyeDaMoA+fNJTSPe5qmchhAbtqhDD/iALri0g9LrEpIOwNaoLmm6lO88sfBUADQrSRSGSWA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.8.1.tgz",
+      "integrity": "sha512-tKE8j1cEZCh8KZa4aa80zpSTxsC2/ZYqjx6AAfd8uA8VHZVw79+7OTEP2PoWi0uL5/1Is0LF5Vwxd+1fz5HlKg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@types/gtag.js": "^0.0.12",
         "tslib": "^2.6.0"
       },
@@ -3757,14 +3559,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.7.0.tgz",
-      "integrity": "sha512-X8U78nb8eiMiPNg3jb9zDIVuuo/rE1LjGDGu+5m5CX4UBZzjMy+klOY2fNya6x8ACyE/L3K2erO1ErheP55W/w==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.8.1.tgz",
+      "integrity": "sha512-iqe3XKITBquZq+6UAXdb1vI0fPY5iIOitVjPQ581R1ZKpHr0qe+V6gVOrrcOHixPDD/BUKdYwkxFjpNiEN+vBw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3776,17 +3578,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.7.0.tgz",
-      "integrity": "sha512-bTRT9YLZ/8I/wYWKMQke18+PF9MV8Qub34Sku6aw/vlZ/U+kuEuRpQ8bTcNOjaTSfYsWkK4tTwDMHK2p5S86cA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.8.1.tgz",
+      "integrity": "sha512-+9YV/7VLbGTq8qNkjiugIelmfUEVkTyLe6X8bWq7K5qPvGXAjno27QAfFq63mYfFFbJc7z+pudL63acprbqGzw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3800,15 +3602,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.7.0.tgz",
-      "integrity": "sha512-HByXIZTbc4GV5VAUkZ2DXtXv1Qdlnpk3IpuImwSnEzCDBkUMYcec5282hPjn6skZqB25M1TYCmWS91UbhBGxQg==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.8.1.tgz",
+      "integrity": "sha512-rW0LWMDsdlsgowVwqiMb/7tANDodpy1wWPwCcamvhY7OECReN3feoFwLjd/U4tKjNY3encj0AJSTxJA+Fpe+Gw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3823,25 +3625,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.7.0.tgz",
-      "integrity": "sha512-nPHj8AxDLAaQXs+O6+BwILFuhiWbjfQWrdw2tifOClQoNfuXDjfjogee6zfx6NGHWqshR23LrcN115DmkHC91Q==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.8.1.tgz",
+      "integrity": "sha512-yJSjYNHXD8POMGc2mKQuj3ApPrN+eG0rO1UPgSx7jySpYU+n4WjBikbrA2ue5ad9A7aouEtMWUoiSRXTH/g7KQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/plugin-content-blog": "3.7.0",
-        "@docusaurus/plugin-content-docs": "3.7.0",
-        "@docusaurus/plugin-content-pages": "3.7.0",
-        "@docusaurus/plugin-debug": "3.7.0",
-        "@docusaurus/plugin-google-analytics": "3.7.0",
-        "@docusaurus/plugin-google-gtag": "3.7.0",
-        "@docusaurus/plugin-google-tag-manager": "3.7.0",
-        "@docusaurus/plugin-sitemap": "3.7.0",
-        "@docusaurus/plugin-svgr": "3.7.0",
-        "@docusaurus/theme-classic": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/theme-search-algolia": "3.7.0",
-        "@docusaurus/types": "3.7.0"
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/plugin-css-cascade-layers": "3.8.1",
+        "@docusaurus/plugin-debug": "3.8.1",
+        "@docusaurus/plugin-google-analytics": "3.8.1",
+        "@docusaurus/plugin-google-gtag": "3.8.1",
+        "@docusaurus/plugin-google-tag-manager": "3.8.1",
+        "@docusaurus/plugin-sitemap": "3.8.1",
+        "@docusaurus/plugin-svgr": "3.8.1",
+        "@docusaurus/theme-classic": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-search-algolia": "3.8.1",
+        "@docusaurus/types": "3.8.1"
       },
       "engines": {
         "node": ">=18.0"
@@ -3852,31 +3655,31 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.7.0.tgz",
-      "integrity": "sha512-MnLxG39WcvLCl4eUzHr0gNcpHQfWoGqzADCly54aqCofQX6UozOS9Th4RK3ARbM9m7zIRv3qbhggI53dQtx/hQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.8.1.tgz",
+      "integrity": "sha512-bqDUCNqXeYypMCsE1VcTXSI1QuO4KXfx8Cvl6rYfY0bhhqN6d2WZlRkyLg/p6pm+DzvanqHOyYlqdPyP0iz+iw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/module-type-aliases": "3.7.0",
-        "@docusaurus/plugin-content-blog": "3.7.0",
-        "@docusaurus/plugin-content-docs": "3.7.0",
-        "@docusaurus/plugin-content-pages": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/theme-translations": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/plugin-content-blog": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/plugin-content-pages": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
         "infima": "0.2.0-alpha.45",
         "lodash": "^4.17.21",
         "nprogress": "^0.2.0",
-        "postcss": "^8.4.26",
+        "postcss": "^8.5.4",
         "prism-react-renderer": "^2.3.0",
         "prismjs": "^1.29.0",
         "react-router-dom": "^5.3.4",
@@ -3893,15 +3696,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.7.0.tgz",
-      "integrity": "sha512-8eJ5X0y+gWDsURZnBfH0WabdNm8XMCXHv8ENy/3Z/oQKwaB/EHt5lP9VsTDTf36lKEp0V6DjzjFyFIB+CetL0A==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.8.1.tgz",
+      "integrity": "sha512-UswMOyTnPEVRvN5Qzbo+l8k4xrd5fTFu2VPPfD6FcW/6qUtVLmJTQCktbAL3KJ0BVXGm5aJXz/ZrzqFuZERGPw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.7.0",
-        "@docusaurus/module-type-aliases": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/mdx-loader": "3.8.1",
+        "@docusaurus/module-type-aliases": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3921,19 +3724,19 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.7.0.tgz",
-      "integrity": "sha512-Al/j5OdzwRU1m3falm+sYy9AaB93S1XF1Lgk9Yc6amp80dNxJVplQdQTR4cYdzkGtuQqbzUA8+kaoYYO0RbK6g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.8.1.tgz",
+      "integrity": "sha512-NBFH5rZVQRAQM087aYSRKQ9yGEK9eHd+xOxQjqNpxMiV85OhJDD4ZGz6YJIod26Fbooy54UWVdzNU0TFeUUUzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docsearch/react": "^3.8.1",
-        "@docusaurus/core": "3.7.0",
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/plugin-content-docs": "3.7.0",
-        "@docusaurus/theme-common": "3.7.0",
-        "@docusaurus/theme-translations": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-validation": "3.7.0",
+        "@docsearch/react": "^3.9.0",
+        "@docusaurus/core": "3.8.1",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/plugin-content-docs": "3.8.1",
+        "@docusaurus/theme-common": "3.8.1",
+        "@docusaurus/theme-translations": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-validation": "3.8.1",
         "algoliasearch": "^5.17.1",
         "algoliasearch-helper": "^3.22.6",
         "clsx": "^2.0.0",
@@ -3952,9 +3755,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.7.0.tgz",
-      "integrity": "sha512-Ewq3bEraWDmienM6eaNK7fx+/lHMtGDHQyd1O+4+3EsDxxUmrzPkV7Ct3nBWTuE0MsoZr3yNwQVKjllzCMuU3g==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.8.1.tgz",
+      "integrity": "sha512-OTp6eebuMcf2rJt4bqnvuwmm3NVXfzfYejL+u/Y1qwKhZPrjPoKWfk1CbOP5xH5ZOPkiAsx4dHdQBRJszK3z2g==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -3965,9 +3768,9 @@
       }
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.7.0.tgz",
-      "integrity": "sha512-kOmZg5RRqJfH31m+6ZpnwVbkqMJrPOG5t0IOl4i/+3ruXyNfWzZ0lVtVrD0u4ONc/0NOsS9sWYaxxWNkH1LdLQ==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.8.1.tgz",
+      "integrity": "sha512-ZPdW5AB+pBjiVrcLuw3dOS6BFlrG0XkS2lDGsj8TizcnREQg3J8cjsgfDviszOk4CweNfwo1AEELJkYaMUuOPg==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4000,15 +3803,16 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.7.0.tgz",
-      "integrity": "sha512-e7zcB6TPnVzyUaHMJyLSArKa2AG3h9+4CfvKXKKWNx6hRs+p0a+u7HHTJBgo6KW2m+vqDnuIHK4X+bhmoghAFA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.8.1.tgz",
+      "integrity": "sha512-P1ml0nvOmEFdmu0smSXOqTS1sxU5tqvnc0dA4MTKV39kye+bhQnjkIKEE18fNOvxjyB86k8esoCIFM3x4RykOQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/types": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/types": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "escape-string-regexp": "^4.0.0",
+        "execa": "5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
@@ -4018,9 +3822,9 @@
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
         "micromatch": "^4.0.5",
+        "p-queue": "^6.6.2",
         "prompts": "^2.4.2",
         "resolve-pathname": "^3.0.0",
-        "shelljs": "^0.8.5",
         "tslib": "^2.6.0",
         "url-loader": "^4.1.1",
         "utility-types": "^3.10.0",
@@ -4031,12 +3835,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.7.0.tgz",
-      "integrity": "sha512-IZeyIfCfXy0Mevj6bWNg7DG7B8G+S6o6JVpddikZtWyxJguiQ7JYr0SIZ0qWd8pGNuMyVwriWmbWqMnK7Y5PwA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.8.1.tgz",
+      "integrity": "sha512-zTZiDlvpvoJIrQEEd71c154DkcriBecm4z94OzEE9kz7ikS3J+iSlABhFXM45mZ0eN5pVqqr7cs60+ZlYLewtg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.7.0",
+        "@docusaurus/types": "3.8.1",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4044,14 +3848,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.7.0.tgz",
-      "integrity": "sha512-w8eiKk8mRdN+bNfeZqC4nyFoxNyI1/VExMKAzD9tqpJfLLbsa46Wfn5wcKH761g9WkKh36RtFV49iL9lh1DYBA==",
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.8.1.tgz",
+      "integrity": "sha512-gs5bXIccxzEbyVecvxg6upTwaUbfa0KMmTj7HhHzc016AGyxH2o73k1/aOD0IFrdCsfJNt37MqNI47s2MgRZMA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.7.0",
-        "@docusaurus/utils": "3.7.0",
-        "@docusaurus/utils-common": "3.7.0",
+        "@docusaurus/logger": "3.8.1",
+        "@docusaurus/utils": "3.8.1",
+        "@docusaurus/utils-common": "3.8.1",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4227,17 +4031,13 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.14.3.tgz",
       "integrity": "sha512-sBJ3XKU9g5Up31jFeXPFsD8AgORV7TLO/cCSMuRewSfgYbG/3vSKLJmfHrO6+PvjZSb9VyV2UaF02ojktW65vw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@module-federation/runtime": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.14.3.tgz",
       "integrity": "sha512-7ZHpa3teUDVhraYdxQGkfGHzPbjna4LtwbpudgzAxSLLFxLDNanaxCuSeIgSM9c+8sVUNC9kvzUgJEZB0krPJw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.14.3",
         "@module-federation/runtime-core": "0.14.3",
@@ -4249,8 +4049,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.14.3.tgz",
       "integrity": "sha512-xMFQXflLVW/AJTWb4soAFP+LB4XuhE7ryiLIX8oTyUoBBgV6U2OPghnFljPjeXbud72O08NYlQ1qsHw1kN/V8Q==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@module-federation/error-codes": "0.14.3",
         "@module-federation/sdk": "0.14.3"
@@ -4261,8 +4059,6 @@
       "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.14.3.tgz",
       "integrity": "sha512-QBETX7iMYXdSa3JtqFlYU+YkpymxETZqyIIRiqg0gW+XGpH3jgU68yjrme2NBJp7URQi/CFZG8KWtfClk0Pjgw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.14.3",
         "@module-federation/webpack-bundler-runtime": "0.14.3"
@@ -4272,17 +4068,13 @@
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.14.3.tgz",
       "integrity": "sha512-THJZMfbXpqjQOLblCQ8jjcBFFXsGRJwUWE9l/Q4SmuCSKMgAwie7yLT0qSGrHmyBYrsUjAuy+xNB4nfKP0pnGw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@module-federation/webpack-bundler-runtime": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.14.3.tgz",
       "integrity": "sha512-hIyJFu34P7bY2NeMIUHAS/mYUHEY71VTAsN0A0AqEJFSVPszheopu9VdXq0VDLrP9KQfuXT8SDxeYeJXyj0mgA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime": "0.14.3",
         "@module-federation/sdk": "0.14.3"
@@ -4375,8 +4167,6 @@
       "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.3.15.tgz",
       "integrity": "sha512-utNPuJglLO5lW9XbwIqjB7+2ilMo6JkuVLTVdnNVKU94FW7asn9F/qV+d+MgjUVqU1QPCGm0NuGO9xhbgeJ7pg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "optionalDependencies": {
         "@rspack/binding-darwin-arm64": "1.3.15",
         "@rspack/binding-darwin-x64": "1.3.15",
@@ -4400,8 +4190,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-darwin-x64": {
       "version": "1.3.15",
@@ -4414,8 +4203,7 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-gnu": {
       "version": "1.3.15",
@@ -4428,8 +4216,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-arm64-musl": {
       "version": "1.3.15",
@@ -4442,8 +4229,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-gnu": {
       "version": "1.3.15",
@@ -4456,8 +4242,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-linux-x64-musl": {
       "version": "1.3.15",
@@ -4470,8 +4255,7 @@
       "optional": true,
       "os": [
         "linux"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-arm64-msvc": {
       "version": "1.3.15",
@@ -4484,8 +4268,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-ia32-msvc": {
       "version": "1.3.15",
@@ -4498,8 +4281,7 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/binding-win32-x64-msvc": {
       "version": "1.3.15",
@@ -4512,16 +4294,13 @@
       "optional": true,
       "os": [
         "win32"
-      ],
-      "peer": true
+      ]
     },
     "node_modules/@rspack/core": {
       "version": "1.3.15",
       "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.3.15.tgz",
       "integrity": "sha512-QuElIC8jXSKWAp0LSx18pmbhA7NiA5HGoVYesmai90UVxz98tud0KpMxTVCg+0lrLrnKZfCWN9kwjCxM5pGnrA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@module-federation/runtime-tools": "0.14.3",
         "@rspack/binding": "1.3.15",
@@ -4856,14 +4635,14 @@
       }
     },
     "node_modules/@swc/core": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.11.31.tgz",
-      "integrity": "sha512-mAby9aUnKRjMEA7v8cVZS9Ah4duoRBnX7X6r5qrhTxErx+68MoY1TPrVwj/66/SWN3Bl+jijqAqoB8Qx0QE34A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.12.0.tgz",
+      "integrity": "sha512-/C0kiMHPY/HnLfqXYGMGxGck3A5Y3mqwxfv+EwHTPHGjAVRfHpWAEEBTSTF5C88vVY6CvwBEkhR2TX7t8Mahcw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3",
-        "@swc/types": "^0.1.21"
+        "@swc/types": "^0.1.22"
       },
       "engines": {
         "node": ">=10"
@@ -4873,16 +4652,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.11.31",
-        "@swc/core-darwin-x64": "1.11.31",
-        "@swc/core-linux-arm-gnueabihf": "1.11.31",
-        "@swc/core-linux-arm64-gnu": "1.11.31",
-        "@swc/core-linux-arm64-musl": "1.11.31",
-        "@swc/core-linux-x64-gnu": "1.11.31",
-        "@swc/core-linux-x64-musl": "1.11.31",
-        "@swc/core-win32-arm64-msvc": "1.11.31",
-        "@swc/core-win32-ia32-msvc": "1.11.31",
-        "@swc/core-win32-x64-msvc": "1.11.31"
+        "@swc/core-darwin-arm64": "1.12.0",
+        "@swc/core-darwin-x64": "1.12.0",
+        "@swc/core-linux-arm-gnueabihf": "1.12.0",
+        "@swc/core-linux-arm64-gnu": "1.12.0",
+        "@swc/core-linux-arm64-musl": "1.12.0",
+        "@swc/core-linux-x64-gnu": "1.12.0",
+        "@swc/core-linux-x64-musl": "1.12.0",
+        "@swc/core-win32-arm64-msvc": "1.12.0",
+        "@swc/core-win32-ia32-msvc": "1.12.0",
+        "@swc/core-win32-x64-msvc": "1.12.0"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -4894,9 +4673,9 @@
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.11.31.tgz",
-      "integrity": "sha512-NTEaYOts0OGSbJZc0O74xsji+64JrF1stmBii6D5EevWEtrY4wlZhm8SiP/qPrOB+HqtAihxWIukWkP2aSdGSQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.12.0.tgz",
+      "integrity": "sha512-usLr8kC80GDv3pwH2zoEaS279kxtWY0MY3blbMFw7zA8fAjqxa8IDxm3WcgyNLNWckWn4asFfguEwz/Weem3nA==",
       "cpu": [
         "arm64"
       ],
@@ -4910,9 +4689,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.11.31.tgz",
-      "integrity": "sha512-THSGaSwT96JwXDwuXQ6yFBbn+xDMdyw7OmBpnweAWsh5DhZmQkALEm1DgdQO3+rrE99MkmzwAfclc0UmYro/OA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.12.0.tgz",
+      "integrity": "sha512-Cvv4sqDcTY7QF2Dh1vn2Xbt/1ENYQcpmrGHzITJrXzxA2aBopsz/n4yQDiyRxTR0t802m4xu0CzMoZIHvVruWQ==",
       "cpu": [
         "x64"
       ],
@@ -4926,9 +4705,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.11.31.tgz",
-      "integrity": "sha512-laKtQFnW7KHgE57Hx32os2SNAogcuIDxYE+3DYIOmDMqD7/1DCfJe6Rln2N9WcOw6HuDbDpyQavIwZNfSAa8vQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.12.0.tgz",
+      "integrity": "sha512-seM4/XMJMOupkzfLfHl8sRa3NdhsVZp+XgwA/vVeYZYJE4wuWUxVzhCYzwmNftVY32eF2IiRaWnhG6ho6jusnQ==",
       "cpu": [
         "arm"
       ],
@@ -4942,9 +4721,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.11.31.tgz",
-      "integrity": "sha512-T+vGw9aPE1YVyRxRr1n7NAdkbgzBzrXCCJ95xAZc/0+WUwmL77Z+js0J5v1KKTRxw4FvrslNCOXzMWrSLdwPSA==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.12.0.tgz",
+      "integrity": "sha512-Al0x33gUVxNY5tutEYpSyv7mze6qQS1ONa0HEwoRxcK9WXsX0NHLTiOSGZoCUS1SsXM37ONlbA6/Bsp1MQyP+g==",
       "cpu": [
         "arm64"
       ],
@@ -4958,9 +4737,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.11.31.tgz",
-      "integrity": "sha512-Mztp5NZkyd5MrOAG+kl+QSn0lL4Uawd4CK4J7wm97Hs44N9DHGIG5nOz7Qve1KZo407Y25lTxi/PqzPKHo61zQ==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.12.0.tgz",
+      "integrity": "sha512-OeFHz/5Hl9v75J9TYA5jQxNIYAZMqaiPpd9dYSTK2Xyqa/ZGgTtNyPhIwVfxx+9mHBf6+9c1mTlXUtACMtHmaQ==",
       "cpu": [
         "arm64"
       ],
@@ -4974,9 +4753,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.11.31.tgz",
-      "integrity": "sha512-DDVE0LZcXOWwOqFU1Xi7gdtiUg3FHA0vbGb3trjWCuI1ZtDZHEQYL4M3/2FjqKZtIwASrDvO96w91okZbXhvMg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.12.0.tgz",
+      "integrity": "sha512-ltIvqNi7H0c5pRawyqjeYSKEIfZP4vv/datT3mwT6BW7muJtd1+KIDCPFLMIQ4wm/h76YQwPocsin3fzmnFdNA==",
       "cpu": [
         "x64"
       ],
@@ -4990,9 +4769,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.11.31.tgz",
-      "integrity": "sha512-mJA1MzPPRIfaBUHZi0xJQ4vwL09MNWDeFtxXb0r4Yzpf0v5Lue9ymumcBPmw/h6TKWms+Non4+TDquAsweuKSw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.12.0.tgz",
+      "integrity": "sha512-Z/DhpjehaTK0uf+MhNB7mV9SuewpGs3P/q9/8+UsJeYoFr7yuOoPbAvrD6AqZkf6Bh7MRZ5OtG+KQgG5L+goiA==",
       "cpu": [
         "x64"
       ],
@@ -5006,9 +4785,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.11.31.tgz",
-      "integrity": "sha512-RdtakUkNVAb/FFIMw3LnfNdlH1/ep6KgiPDRlmyUfd0WdIQ3OACmeBegEFNFTzi7gEuzy2Yxg4LWf4IUVk8/bg==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.12.0.tgz",
+      "integrity": "sha512-wHnvbfHIh2gfSbvuFT7qP97YCMUDh+fuiso+pcC6ug8IsMxuViNapHET4o0ZdFNWHhXJ7/s0e6w7mkOalsqQiQ==",
       "cpu": [
         "arm64"
       ],
@@ -5022,9 +4801,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.11.31.tgz",
-      "integrity": "sha512-hErXdCGsg7swWdG1fossuL8542I59xV+all751mYlBoZ8kOghLSKObGQTkBbuNvc0sUKWfWg1X0iBuIhAYar+w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.12.0.tgz",
+      "integrity": "sha512-88umlXwK+7J2p4DjfWHXQpmlZgCf1ayt6Ssj+PYlAfMCR0aBiJoAMwHWrvDXEozyOrsyP1j2X6WxbmA861vL5Q==",
       "cpu": [
         "ia32"
       ],
@@ -5038,9 +4817,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.11.31.tgz",
-      "integrity": "sha512-5t7SGjUBMMhF9b5j17ml/f/498kiBJNf4vZFNM421UGUEETdtjPN9jZIuQrowBkoFGJTCVL/ECM4YRtTH30u/A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.12.0.tgz",
+      "integrity": "sha512-KR9TSRp+FEVOhbgTU6c94p/AYpsyBk7dIvlKQiDp8oKScUoyHG5yjmMBFN/BqUyTq4kj6zlgsY2rFE4R8/yqWg==",
       "cpu": [
         "x64"
       ],
@@ -5060,9 +4839,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/html": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.11.31.tgz",
-      "integrity": "sha512-KNgCP+wF+38piQj6Rv5tZyHBkEavtm7UxEgS/fU3T6wavj0Cj3NnOGVgOMJoN9YqpE2+wMWQARz3xZnUfXdXzg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html/-/html-1.12.1.tgz",
+      "integrity": "sha512-xHFfRBH4L1Mq3qmjqCajtE9vKWg6eLul+N/LkVX7AdmpksTfkXaxjpT9ebVJii08QZOnQEIIkfkGvugB09brGw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5071,22 +4850,22 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@swc/html-darwin-arm64": "1.11.31",
-        "@swc/html-darwin-x64": "1.11.31",
-        "@swc/html-linux-arm-gnueabihf": "1.11.31",
-        "@swc/html-linux-arm64-gnu": "1.11.31",
-        "@swc/html-linux-arm64-musl": "1.11.31",
-        "@swc/html-linux-x64-gnu": "1.11.31",
-        "@swc/html-linux-x64-musl": "1.11.31",
-        "@swc/html-win32-arm64-msvc": "1.11.31",
-        "@swc/html-win32-ia32-msvc": "1.11.31",
-        "@swc/html-win32-x64-msvc": "1.11.31"
+        "@swc/html-darwin-arm64": "1.12.1",
+        "@swc/html-darwin-x64": "1.12.1",
+        "@swc/html-linux-arm-gnueabihf": "1.12.1",
+        "@swc/html-linux-arm64-gnu": "1.12.1",
+        "@swc/html-linux-arm64-musl": "1.12.1",
+        "@swc/html-linux-x64-gnu": "1.12.1",
+        "@swc/html-linux-x64-musl": "1.12.1",
+        "@swc/html-win32-arm64-msvc": "1.12.1",
+        "@swc/html-win32-ia32-msvc": "1.12.1",
+        "@swc/html-win32-x64-msvc": "1.12.1"
       }
     },
     "node_modules/@swc/html-darwin-arm64": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.11.31.tgz",
-      "integrity": "sha512-/BZ7KLfkua568iNNnLAlxa88P7gBiouZ+aW7LFcqfv62ueCpjLY7YSUXcVcb8bAoGwDcB+fO2xMYz5ABHcaFZg==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-arm64/-/html-darwin-arm64-1.12.1.tgz",
+      "integrity": "sha512-vbCqYgBBdoxlsnUe/G6irBJ69LUOrlLVXgdxWxDSZ3YcbnpVmwi5YEeaRvqf4vNzZ/nzBMd4DYl6KK2Qsi0prw==",
       "cpu": [
         "arm64"
       ],
@@ -5100,9 +4879,9 @@
       }
     },
     "node_modules/@swc/html-darwin-x64": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.11.31.tgz",
-      "integrity": "sha512-J/gRwto/pxeKm4+fpS/ynn748dhRzsOrJKFHoFkDE79WRwxgbTkQUwLwn1AC336ssE9Bx0XvyJZI93hjs7JNyA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-darwin-x64/-/html-darwin-x64-1.12.1.tgz",
+      "integrity": "sha512-74/qUSMV0f82ozRhXAcVLHf9+6m72WPjQvxLgXffnnXSgg4h6PtrVlZkMZ0JjLeFbCD5mWcWnaVJtmgePxLdMg==",
       "cpu": [
         "x64"
       ],
@@ -5116,9 +4895,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm-gnueabihf": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.11.31.tgz",
-      "integrity": "sha512-cQo3snjtWnPl1AdC8JA6vANsO01ksCE81jNKxxJxnlkN/iP9F4nWG41/UboKsRK+sdyyFUoSJqz2HGy6aU4izA==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm-gnueabihf/-/html-linux-arm-gnueabihf-1.12.1.tgz",
+      "integrity": "sha512-Zfn8texf/x1EEBGTg4JcNplzoveiEz7KNYdg65jCy4MFo8X0X3q4y6HplV0+CLYm34OiA7o2W2Sk/5BC7K9mSw==",
       "cpu": [
         "arm"
       ],
@@ -5132,9 +4911,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm64-gnu": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.11.31.tgz",
-      "integrity": "sha512-3rbfgMDGeLx52iFOCGaeeK8IEj1fT7gsvTWfXACJ4ns7MPupz6v3dVoGCIuzh0yHGAZPY0QL1iVAYjPLg8TrWw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-gnu/-/html-linux-arm64-gnu-1.12.1.tgz",
+      "integrity": "sha512-KbqPLtsPVt0/kjp7sUT1APfEtNQUqMam3S0RzJkvuMz9jB2F9DREvj5EG+DPnx2s/kxnDm4sh9vM2sG2xNHErQ==",
       "cpu": [
         "arm64"
       ],
@@ -5148,9 +4927,9 @@
       }
     },
     "node_modules/@swc/html-linux-arm64-musl": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.11.31.tgz",
-      "integrity": "sha512-vUKGadmgQaN5WtEHoXsihWKKeiTNxQ/hv4W7FejPNnV3EOBG0pcxKqMXqlXfzEP8ij2bnqy+JauW4RRX3PnV4g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-arm64-musl/-/html-linux-arm64-musl-1.12.1.tgz",
+      "integrity": "sha512-8JtGeBGpKiOrjcD7Xyefi6+IlNiH6MWNR86fK0suXYFgeaceRF9tgH/p/iX84LvzPQOsWd6oL/gMbSl7P3Whcg==",
       "cpu": [
         "arm64"
       ],
@@ -5164,9 +4943,9 @@
       }
     },
     "node_modules/@swc/html-linux-x64-gnu": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.11.31.tgz",
-      "integrity": "sha512-6w9yZ1W23y17Y8NLTqy+efaAHjnqumSdn8PdCmBvMxwFRwjo9dNkkcDJsTZ5EERBMH+DnDbVR+HkuNypd0Y7Gw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-gnu/-/html-linux-x64-gnu-1.12.1.tgz",
+      "integrity": "sha512-9QNCTgCZtyQVifLXqDTW7v4lgaC11v0/iL9OhsSZ19ycJrBmnxBmZtDIbuQrXAIzE1GD8mMOK/GLey2IeceoDQ==",
       "cpu": [
         "x64"
       ],
@@ -5180,9 +4959,9 @@
       }
     },
     "node_modules/@swc/html-linux-x64-musl": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.11.31.tgz",
-      "integrity": "sha512-P/OSc/JlbCVfpZWg1eDhFJRC0iP3/PfP77MM/e01WFtM1QhriPBpYAOIXSdfWsPNGXa8keFP4vzm8BBNYyVKvw==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-linux-x64-musl/-/html-linux-x64-musl-1.12.1.tgz",
+      "integrity": "sha512-evJOJqOJJC4ZPSBDZ8g+9NQVI+dZrBE2U8bWHlEaJ6s28llxWfHEjFX/sgzrxVNbvh8hDlj4xyP0lXJr3hVQFw==",
       "cpu": [
         "x64"
       ],
@@ -5196,9 +4975,9 @@
       }
     },
     "node_modules/@swc/html-win32-arm64-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.11.31.tgz",
-      "integrity": "sha512-/dlryiXq3SsXgV9FcG3klAE9kVVT7dW4eaiRpsW31GErlnVdTQ46rU6v2t+kqROmyW+LUpqo80ZGyynyeDS8Ag==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-arm64-msvc/-/html-win32-arm64-msvc-1.12.1.tgz",
+      "integrity": "sha512-FNiqI6VGOSW/OzOKEsCxvpaMemMtPV6phHxzKMz0kH6e1JlwvVFNVNtuDv1Xc7T0TfSrV4kAdL7x4pn7QN8gfQ==",
       "cpu": [
         "arm64"
       ],
@@ -5212,9 +4991,9 @@
       }
     },
     "node_modules/@swc/html-win32-ia32-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.11.31.tgz",
-      "integrity": "sha512-PEqJca+mFz0wvmmODEgrcuoNyV7Oz5Tl6ttHOrk54dv4q8nErw/oH3xUdap2CL0uDeWV2Xbd2OXFXAMc3keK2g==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-ia32-msvc/-/html-win32-ia32-msvc-1.12.1.tgz",
+      "integrity": "sha512-GuzRUlRofk6nUzeb3QB/Az60iB89j9BVxm7Svh9MxAIpKdeJVUe7iQ52ZDxSR8Nd7p1qUV2OCSfV5aoShUw2vg==",
       "cpu": [
         "ia32"
       ],
@@ -5228,9 +5007,9 @@
       }
     },
     "node_modules/@swc/html-win32-x64-msvc": {
-      "version": "1.11.31",
-      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.11.31.tgz",
-      "integrity": "sha512-TngLrcUJCA+U0P3YKe/8Tx7/MGeD45rDK4gY390ELIP3pNtUIW1dkfYasEexvG9NYb5u+hzJAg/Wf2ahztTIIQ==",
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/@swc/html-win32-x64-msvc/-/html-win32-x64-msvc-1.12.1.tgz",
+      "integrity": "sha512-ozPsc9UqLT5KXg1XnsFTuSUKs4VmsWxDKrGJV1PMKYXcNzOi+Ntq4Mchhco4KHl7dj6L640FiCkKjRvdqfpl8A==",
       "cpu": [
         "x64"
       ],
@@ -5244,9 +5023,9 @@
       }
     },
     "node_modules/@swc/types": {
-      "version": "0.1.22",
-      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.22.tgz",
-      "integrity": "sha512-D13mY/ZA4PPEFSy6acki9eBT/3WgjMoRqNcdpIvjaYLQ44Xk5BdaL7UkDxAh6Z9UOe7tCCp67BVmZCojYp9owg==",
+      "version": "0.1.23",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
+      "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -5497,12 +5276,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "22.15.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
-      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "version": "24.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.1.tgz",
+      "integrity": "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/@types/node-forge": {
@@ -5513,12 +5292,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
-      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==",
-      "license": "MIT"
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.5",
@@ -5539,9 +5312,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.6.tgz",
-      "integrity": "sha512-JeG0rEWak0N6Itr6QUx+X60uQmN+5t3j9r/OVDtWzFXKaj6kD1BwJzOksD0FF6iWxZlbE1kB0q9vtnU2ekqa1Q==",
+      "version": "19.1.8",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
+      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -6147,15 +5920,6 @@
         "astring": "bin/astring"
       }
     },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 4.0.0"
-      }
-    },
     "node_modules/autoprefixer": {
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
@@ -6397,9 +6161,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -6583,9 +6347,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001721",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001721.tgz",
-      "integrity": "sha512-cOuvmUVtKrtEaoKiO0rSc29jcjwMwX5tOHDy4MgVFEWiUXj4uBMJkwI8MDySkgXidpMiHUcviogAvFi4pA2hDQ==",
+      "version": "1.0.30001722",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001722.tgz",
+      "integrity": "sha512-DCQHBBZtiK6JVkAGw7drvAMK0Q0POD/xZvEmDp6baiMMP6QXXk9HpD6mNYBZWhOPG6LvIDb82ITqtWjhDckHCA==",
       "funding": [
         {
           "type": "opencollective",
@@ -7016,6 +6780,12 @@
         "proto-list": "~1.2.1"
       }
     },
+    "node_modules/config-chain/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/configstore": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-6.0.0.tgz",
@@ -7172,9 +6942,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.42.0.tgz",
-      "integrity": "sha512-Sz4PP4ZA+Rq4II21qkNqOEDTDrCvcANId3xpIgB34NDkWc3UduWj2dqEtN9yZIq8Dk3HyPI33x9sqqU5C8sr0g==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.43.0.tgz",
+      "integrity": "sha512-N6wEbTTZSYOY2rYAn85CuvWWkCK6QweMn7/4Nr3w+gDBeBhk/x4EJeY6FPo4QzDoJZxVTv8U7CMvgWk6pOHHqA==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -7183,12 +6953,12 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
-      "integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.43.0.tgz",
+      "integrity": "sha512-2GML2ZsCc5LR7hZYz4AXmjQw8zuy2T//2QntwdnpuYI7jteT6GVYJL7F6C2C57R7gSYrcqVW3lAALefdbhBLDA==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.24.4"
+        "browserslist": "^4.25.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7196,9 +6966,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.42.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.42.0.tgz",
-      "integrity": "sha512-007bM04u91fF4kMgwom2I5cQxAFIy8jVulgr9eozILl/SZE53QOqnW/+vviC+wQWLv+AunBG+8Q0TLoeSsSxRQ==",
+      "version": "3.43.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.43.0.tgz",
+      "integrity": "sha512-i/AgxU2+A+BbJdMxh3v7/vxi2SbFqxiFmg6VsDwYB4jkucrd1BZNA9a9gphC0fYMG5IBSgQcbQnk865VCLe7xA==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
@@ -7842,28 +7612,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/del": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-6.1.1.tgz",
-      "integrity": "sha512-ua8BhapfP0JUJKC/zV9yHHDW/rDoDxP4Zhn3AkA6/xT6gY7jYXJiaeyBZznYVujhZZET+UgcbZiQ7sN3WqcImg==",
-      "license": "MIT",
-      "dependencies": {
-        "globby": "^11.0.1",
-        "graceful-fs": "^4.2.4",
-        "is-glob": "^4.0.1",
-        "is-path-cwd": "^2.2.0",
-        "is-path-inside": "^3.0.2",
-        "p-map": "^4.0.0",
-        "rimraf": "^3.0.2",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -7923,38 +7671,6 @@
       "engines": {
         "node": ">= 4.0.0"
       }
-    },
-    "node_modules/detect-port-alt": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/detect-port-alt/-/detect-port-alt-1.1.6.tgz",
-      "integrity": "sha512-5tQykt+LqfJFBEYaDITx7S7cR7mJ/zQmLXZ2qt5w04ainYZw6tBf9dBunMjVeVOdYVRUzUOE4HkY5J7+uttb5Q==",
-      "license": "MIT",
-      "dependencies": {
-        "address": "^1.0.1",
-        "debug": "^2.6.0"
-      },
-      "bin": {
-        "detect": "bin/detect-port",
-        "detect-port": "bin/detect-port"
-      },
-      "engines": {
-        "node": ">= 4.2.1"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/debug": {
-      "version": "2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/detect-port-alt/node_modules/ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
     },
     "node_modules/devlop": {
       "version": "1.1.0",
@@ -8124,9 +7840,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.165",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.165.tgz",
-      "integrity": "sha512-naiMx1Z6Nb2TxPU6fiFrUrDTjyPMLdTtaOd2oLmG8zVSg2hCWGkhPyxwk+qRmZ1ytwVqUv0u7ZcDA5+ALhaUtw==",
+      "version": "1.5.167",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.167.tgz",
+      "integrity": "sha512-LxcRvnYO5ez2bMOFpbuuVuAI5QNeY1ncVytE/KXaL6ZNfzX1yPlAO0nSOyIHx2fVAuUprMqPs/TdVhUFZy7SIQ==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8838,15 +8554,6 @@
         "url": "https://opencollective.com/webpack"
       }
     },
-    "node_modules/filesize": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/filesize/-/filesize-8.0.7.tgz",
-      "integrity": "sha512-pjmC+bkIF8XI7fWaH8KxHcZL3DPybs1roSKP4rKDvy20tAWwIObE4+JIseG2byfGKhud5ZnM4YSGKBz7Sh0ndQ==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">= 0.4.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -8951,134 +8658,6 @@
         "debug": {
           "optional": true
         }
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.3.tgz",
-      "integrity": "sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.8.3",
-        "@types/json-schema": "^7.0.5",
-        "chalk": "^4.1.0",
-        "chokidar": "^3.4.2",
-        "cosmiconfig": "^6.0.0",
-        "deepmerge": "^4.2.2",
-        "fs-extra": "^9.0.0",
-        "glob": "^7.1.6",
-        "memfs": "^3.1.2",
-        "minimatch": "^3.0.4",
-        "schema-utils": "2.7.0",
-        "semver": "^7.3.2",
-        "tapable": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=10",
-        "yarn": ">=1.0.0"
-      },
-      "peerDependencies": {
-        "eslint": ">= 6",
-        "typescript": ">= 2.7",
-        "vue-template-compiler": "*",
-        "webpack": ">= 4"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        },
-        "vue-template-compiler": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/ajv-keywords": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^6.9.1"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/cosmiconfig": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
-      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/parse-json": "^4.0.0",
-        "import-fresh": "^3.1.0",
-        "parse-json": "^5.0.0",
-        "path-type": "^4.0.0",
-        "yaml": "^1.7.2"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "license": "MIT",
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "license": "MIT"
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/schema-utils": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-      "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/json-schema": "^7.0.4",
-        "ajv": "^6.12.2",
-        "ajv-keywords": "^3.4.1"
-      },
-      "engines": {
-        "node": ">= 8.9.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/fork-ts-checker-webpack-plugin/node_modules/tapable": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/form-data-encoder": {
@@ -9300,53 +8879,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/global-dirs/node_modules/ini": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
-      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/global-modules": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
-      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
-      "license": "MIT",
-      "dependencies": {
-        "global-prefix": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
-      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
-      "license": "MIT",
-      "dependencies": {
-        "ini": "^1.3.5",
-        "kind-of": "^6.0.2",
-        "which": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/global-prefix/node_modules/which": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
-      "bin": {
-        "which": "bin/which"
       }
     },
     "node_modules/globals": {
@@ -10095,28 +9627,15 @@
       }
     },
     "node_modules/image-size": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
+      "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
       "license": "MIT",
-      "dependencies": {
-        "queue": "6.0.2"
-      },
       "bin": {
         "image-size": "bin/image-size.js"
       },
       "engines": {
         "node": ">=16.x"
-      }
-    },
-    "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -10189,25 +9708,19 @@
       "license": "ISC"
     },
     "node_modules/ini": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.4.tgz",
       "integrity": "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==",
       "license": "MIT"
-    },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/invariant": {
       "version": "2.2.4",
@@ -10416,15 +9929,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/is-path-inside": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -10465,15 +9969,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-root": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-root/-/is-root-2.1.0.tgz",
-      "integrity": "sha512-AGOriNp96vNBd3HtU+RzFEc75FfR5ymiYv8E553I71SCeXBiMsVDUtdio1OEFvrPyLIQ9tVR5RxXIFe5PUFjMg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/is-stream": {
@@ -10534,15 +10029,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/isomorphic-rslog": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/isomorphic-rslog/-/isomorphic-rslog-0.0.6.tgz",
-      "integrity": "sha512-HM0q6XqQ93psDlqvuViNs/Ea3hAyGDkIdVAHlrEocjjAwGrs1fZ+EdQjS9eUPacnYB7Y8SoDdSY3H8p3ce205A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.17.6"
       }
     },
     "node_modules/jest-util": {
@@ -13618,9 +13104,9 @@
       }
     },
     "node_modules/normalize-url": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.1.tgz",
-      "integrity": "sha512-IO9QvjUMWxPQQhs60oOu10CRkWCiZzSUkzbXGGV9pviYl1fXYcvkzQ5jV9z8Y6un8ARoVRl4EtC6v6jNqbaJ/w==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.2.tgz",
+      "integrity": "sha512-Ee/R3SyN4BuynXcnTaekmaVdbDAEiNrHqjQIA37mHU8G9pf7aaAD4ZX3XjBLo6rsdcxA/gtkcNYZLt30ACgynw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.16"
@@ -13864,6 +13350,15 @@
         "node": ">=12.20"
       }
     },
+    "node_modules/p-finally": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+      "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/p-limit": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
@@ -13909,6 +13404,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-queue": {
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+      "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^4.0.4",
+        "p-timeout": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-retry": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
@@ -13922,13 +13433,16 @@
         "node": ">=8"
       }
     },
-    "node_modules/p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+    "node_modules/p-timeout": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+      "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
       "license": "MIT",
+      "dependencies": {
+        "p-finally": "^1.0.0"
+      },
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/package-json": {
@@ -14166,83 +13680,10 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
-      "license": "MIT",
-      "dependencies": {
-        "find-up": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/pkg-up/node_modules/find-up": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/locate-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^3.0.0",
-        "path-exists": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-limit": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-      "license": "MIT",
-      "dependencies": {
-        "p-try": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/pkg-up/node_modules/p-locate": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/pkg-up/node_modules/path-exists": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-      "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/postcss": {
-      "version": "8.5.4",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
-      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "version": "8.5.5",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.5.tgz",
+      "integrity": "sha512-d/jtm+rdNT8tpXuHY5MMtcbJFBkhXE6593XVR9UoGCH8jSFGci7jGvMGH5RYd5PBJW+00NZQt6gf7CbagJCrhg==",
       "funding": [
         {
           "type": "opencollective",
@@ -15086,9 +14527,9 @@
       }
     },
     "node_modules/postcss-nesting": {
-      "version": "13.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.1.tgz",
-      "integrity": "sha512-VbqqHkOBOt4Uu3G8Dm8n6lU5+9cJFxiuty9+4rcoyRPO9zZS1JIs6td49VIoix3qYqELHlJIn46Oih9SAKo+yQ==",
+      "version": "13.0.2",
+      "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-13.0.2.tgz",
+      "integrity": "sha512-1YCI290TX+VP0U/K/aFxzHzQWHWURL+CtHMSbex1lCdpXD1SoR2sYuxDu5aNI9lPoXpKTCggFZiDJbwylU0LEQ==",
       "funding": [
         {
           "type": "github",
@@ -15101,7 +14542,7 @@
       ],
       "license": "MIT-0",
       "dependencies": {
-        "@csstools/selector-resolve-nested": "^3.0.0",
+        "@csstools/selector-resolve-nested": "^3.1.0",
         "@csstools/selector-specificity": "^5.0.0",
         "postcss-selector-parser": "^7.0.0"
       },
@@ -15400,9 +14841,9 @@
       }
     },
     "node_modules/postcss-preset-env": {
-      "version": "10.2.1",
-      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.1.tgz",
-      "integrity": "sha512-mDInnlm4mYhmR0S79hNLzseW9nx4Ihd8s15K99iu6u6QhoSQgqWX9Oj6nTd/8Dz3b0T7v2JSrfnXsDfv9TFvDg==",
+      "version": "10.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-preset-env/-/postcss-preset-env-10.2.3.tgz",
+      "integrity": "sha512-zlQN1yYmA7lFeM1wzQI14z97mKoM8qGng+198w1+h6sCud/XxOjcKtApY9jWr7pXNS3yHDEafPlClSsWnkY8ow==",
       "funding": [
         {
           "type": "github",
@@ -15427,7 +14868,7 @@
         "@csstools/postcss-hwb-function": "^4.0.10",
         "@csstools/postcss-ic-unit": "^4.0.2",
         "@csstools/postcss-initial": "^2.0.1",
-        "@csstools/postcss-is-pseudo-class": "^5.0.1",
+        "@csstools/postcss-is-pseudo-class": "^5.0.3",
         "@csstools/postcss-light-dark-function": "^2.0.9",
         "@csstools/postcss-logical-float-and-clear": "^3.0.0",
         "@csstools/postcss-logical-overflow": "^2.0.0",
@@ -15471,7 +14912,7 @@
         "postcss-image-set-function": "^7.0.0",
         "postcss-lab-function": "^7.0.10",
         "postcss-logical": "^8.1.0",
-        "postcss-nesting": "^13.0.1",
+        "postcss-nesting": "^13.0.2",
         "postcss-opacity-percentage": "^3.0.0",
         "postcss-overflow-shorthand": "^6.0.0",
         "postcss-page-break": "^3.0.4",
@@ -15843,15 +15284,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/queue": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "~2.0.3"
-      }
-    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -15941,6 +15373,12 @@
         "rc": "cli.js"
       }
     },
+    "node_modules/rc/node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "license": "ISC"
+    },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
@@ -15959,132 +15397,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-dev-utils": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-12.0.1.tgz",
-      "integrity": "sha512-84Ivxmr17KjUupyqzFode6xKhjwuEJDROWKJy/BthkL7Wn6NJ8h4WE6k/exAv6ImS+0oZLRRW5j/aINMHyeGeQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.16.0",
-        "address": "^1.1.2",
-        "browserslist": "^4.18.1",
-        "chalk": "^4.1.2",
-        "cross-spawn": "^7.0.3",
-        "detect-port-alt": "^1.1.6",
-        "escape-string-regexp": "^4.0.0",
-        "filesize": "^8.0.6",
-        "find-up": "^5.0.0",
-        "fork-ts-checker-webpack-plugin": "^6.5.0",
-        "global-modules": "^2.0.0",
-        "globby": "^11.0.4",
-        "gzip-size": "^6.0.0",
-        "immer": "^9.0.7",
-        "is-root": "^2.1.0",
-        "loader-utils": "^3.2.0",
-        "open": "^8.4.0",
-        "pkg-up": "^3.1.0",
-        "prompts": "^2.4.2",
-        "react-error-overlay": "^6.0.11",
-        "recursive-readdir": "^2.2.2",
-        "shell-quote": "^1.7.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "license": "MIT",
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/loader-utils": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-3.3.1.tgz",
-      "integrity": "sha512-FMJTLMXfCLMLfJxcX9PFqX5qD88Z5MRGaZCVzfuqeZSPsyiBzs+pahDQjbIWz2QIzPZz0NX9Zy4FX3lmK6YHIg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 12.13.0"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "license": "MIT",
-      "dependencies": {
-        "yocto-queue": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/react-dev-utils/node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -16096,12 +15408,6 @@
       "peerDependencies": {
         "react": "^19.1.0"
       }
-    },
-    "node_modules/react-error-overlay": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.1.0.tgz",
-      "integrity": "sha512-SN/U6Ytxf1QGkw/9ve5Y+NxBbZM6Ht95tuXNMKs8EJyFa/Vy/+Co3stop3KBHARfn/giv+Lj1uUnTfOJ3moFEQ==",
-      "license": "MIT"
     },
     "node_modules/react-fast-compare": {
       "version": "3.2.2",
@@ -16132,6 +15438,18 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-json-view-lite": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/react-json-view-lite/-/react-json-view-lite-2.4.1.tgz",
+      "integrity": "sha512-fwFYknRIBxjbFm0kBDrzgBy1xa5tDg2LyXXBepC5f1b+MY3BUClMCsvanMPn089JbV1Eg3nZcrp0VCuH43aXnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-loadable": {
       "name": "@docusaurus/react-loadable",
@@ -16239,23 +15557,6 @@
         "node": ">=8.10.0"
       }
     },
-    "node_modules/reading-time": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/reading-time/-/reading-time-1.5.0.tgz",
-      "integrity": "sha512-onYyVhBNr4CmAxFsKS7bz+uTLRakypIe4R+5A824vBSkQy/hB3fZepoVEf8OVAxzLvK+H/jm9TzpI3ETSm64Kg==",
-      "license": "MIT"
-    },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/recma-build-jsx": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/recma-build-jsx/-/recma-build-jsx-1.0.0.tgz",
@@ -16318,18 +15619,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/recursive-readdir": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/recursive-readdir/-/recursive-readdir-2.2.3.tgz",
-      "integrity": "sha512-8HrF5ZsXk5FAH9dgsx3BlUer73nIhuj+9OrQwEbLTPOBzGkL1lsFCR01am+v+0m2Cmbs1nP12hLDl5FA7EszKA==",
-      "license": "MIT",
-      "dependencies": {
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/regenerate": {
@@ -16893,6 +16182,12 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/schema-dts": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/schema-dts/-/schema-dts-1.1.5.tgz",
+      "integrity": "sha512-RJr9EaCmsLzBX2NDiO5Z3ux2BVosNZN5jo0gWgsyKvxKIUL5R3swNvoorulAeL9kLB0iTSX7V6aokhla2m7xbg==",
+      "license": "Apache-2.0"
+    },
     "node_modules/schema-utils": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
@@ -17230,23 +16525,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/shelljs": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz",
-      "integrity": "sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/side-channel": {
@@ -17777,9 +17055,9 @@
       }
     },
     "node_modules/terser": {
-      "version": "5.41.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.41.0.tgz",
-      "integrity": "sha512-H406eLPXpZbAX14+B8psIuvIr8+3c+2hkuYzpMkoE0ij+NdsVATbA78vb8neA/eqrj7rywa2pIkdmWRsXW6wmw==",
+      "version": "5.42.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.42.0.tgz",
+      "integrity": "sha512-UYCvU9YQW2f/Vwl+P0GfhxJxbUGLwd+5QrrGgLajzWAtC/23AX0vcise32kkP7Eu0Wu9VlzzHAXkLObgjQfFlQ==",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@jridgewell/source-map": "^0.3.3",
@@ -17863,12 +17141,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "license": "MIT"
-    },
     "node_modules/thunky": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
@@ -17886,6 +17158,15 @@
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==",
       "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.0.tgz",
+      "integrity": "sha512-7CotroY9a8DKsKprEy/a14aCCm8jYVmR7aFy4fpkZM8sdpNJbKkixuNjgM50yCmip2ezc8z4N7k3oe2+rfRJCQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -17998,24 +17279,10 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "node_modules/typescript": {
-      "version": "5.8.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "license": "Apache-2.0",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
-      }
-    },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
@@ -19052,15 +18319,6 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
-    },
-    "node_modules/yaml": {
-      "version": "1.10.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
-      "license": "ISC",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "1.2.1",

--- a/site/package.json
+++ b/site/package.json
@@ -14,10 +14,10 @@
     "write-heading-ids": "docusaurus write-heading-ids"
   },
   "dependencies": {
-    "@docusaurus/core": "3.7.0",
-    "@docusaurus/faster": "3.7.0",
-    "@docusaurus/plugin-client-redirects": "3.7.0",
-    "@docusaurus/preset-classic": "3.7.0",
+    "@docusaurus/core": "3.8.1",
+    "@docusaurus/faster": "3.8.1",
+    "@docusaurus/plugin-client-redirects": "3.8.1",
+    "@docusaurus/preset-classic": "3.8.1",
     "@mdx-js/react": "^3.1.0",
     "clsx": "^2.1.1",
     "prism-react-renderer": "^2.4.1",
@@ -25,8 +25,8 @@
     "react-dom": "^19.1.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.7.0",
-    "@docusaurus/types": "3.7.0"
+    "@docusaurus/module-type-aliases": "3.8.1",
+    "@docusaurus/types": "3.8.1"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
This change bumps the version of `docusaurus` from v3.7.0 to v3.8.1. There are no new features or bug fixes that need to be accounted for. The changes were tested locally by successfully building and serving the site. Changelogs for the versions included in this upgrade:

* [v3.8.0](https://github.com/facebook/docusaurus/releases/tag/v3.8.0)
* [v3.8.1](https://github.com/facebook/docusaurus/releases/tag/v3.8.1)

The next major version of Docusaurus (v4) is coming and there are [Future Flags](https://docusaurus.io/blog/releases/3.8#future-flags) that can be opted into to prepare for that release. All of those flags were accepted.
