### PR TITLE
Remove references to the free Community version

### DIFF
--- a/docs/home/welcome.md
+++ b/docs/home/welcome.md
@@ -8,17 +8,24 @@ slug: /
 
 ---
 
-Not a user yet? Get the free version [here](https://app.phylum.io/register).
+> 💡 **INFO** 💡
+>
+> The free Community version of Phylum was sunset on 24 February 2025.
+> Phylum is now only available for teams and Enterprise organizations.
+> Unfortunately, this means we are no longer supporting individual licensing.
+> We invite existing users to convert to a paid version of the product.
+
+Not a user yet? Connect with the [Veracode sales team](https://www.veracode.com/contact-us/)
+to create an account.
 
 [Quickstart](../cli/quickstart.md) -> (set up takes less than 10 minutes)
 
-**OR** install our [GitHub App](https://github.com/marketplace/phylum-io) (a
-free account is created automatically and set up takes 5 minutes)
+**OR** install our [GitHub App](https://github.com/marketplace/phylum-io)
 
 ---
 
-Phylum provides a comprehensive, scalable approach to defending your software supply chain.
-Get started with one or all of the below capabilities.
+Phylum provides a comprehensive, scalable approach to defending your software
+supply chain. Get started with one or all of the below capabilities.
 
 ## Detect & Prevent
 

--- a/docs/support/contact_us.md
+++ b/docs/support/contact_us.md
@@ -1,5 +1,11 @@
 # Contact Us
 
-We'd love to answer your questions or provide recommendations on your unique environment! Search our documentation, contact [support](mailto:phylum@veracode.com), or connect with our [sales team](mailto:phylum@veracode.com).
+We'd love to answer your questions or provide recommendations on your unique
+environment! Search our documentation, contact [support][phylum_support], or
+connect with our [sales team][vc_contact].
 
-Also, join us on the [Phylum Community Discord](https://discord.gg/Fe6pr5eW6p)!
+Also, join us on the [Phylum Community Discord][discord]!
+
+[phylum_support]: mailto:phylum@veracode.com
+[discord]: https://discord.gg/Fe6pr5eW6p
+[vc_contact]: https://www.veracode.com/contact-us/


### PR DESCRIPTION
This change was initiated due to a potential customer reading the documentation and following the link to register for the free version. When it didn't work for them, they used the contact info published on the site to ask about the issue. I informed them of the new model of operations and told them we would update the documentation to match. This is that update.
